### PR TITLE
fix: require ziti identity

### DIFF
--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -97,8 +97,6 @@ env:
     value: "info"
   - name: ZITI_IDENTITY_FILE
     value: ""
-  - name: DISABLE_ZITI
-    value: "true"
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -86,22 +86,18 @@ func run() error {
 	defer listener.Close()
 	startServe(listener, "tcp")
 
-	if cfg.DisableZiti {
-		logger.Info("ziti disabled")
-	} else {
-		zitiContext, err := ziti.NewContextFromFile(cfg.ZitiIdentityFile)
-		if err != nil {
-			return fmt.Errorf("create ziti context: %w", err)
-		}
-		defer zitiContext.Close()
-
-		zitiListener, err := zitiContext.ListenWithOptions(cfg.ZitiServiceName, ziti.DefaultListenOptions())
-		if err != nil {
-			return fmt.Errorf("listen on ziti service %s: %w", cfg.ZitiServiceName, err)
-		}
-		defer zitiListener.Close()
-		startServe(zitiListener, "ziti")
+	zitiContext, err := ziti.NewContextFromFile(cfg.ZitiIdentityFile)
+	if err != nil {
+		return fmt.Errorf("create ziti context: %w", err)
 	}
+	defer zitiContext.Close()
+
+	zitiListener, err := zitiContext.ListenWithOptions(cfg.ZitiServiceName, ziti.DefaultListenOptions())
+	if err != nil {
+		return fmt.Errorf("listen on ziti service %s: %w", cfg.ZitiServiceName, err)
+	}
+	defer zitiListener.Close()
+	startServe(zitiListener, "ziti")
 
 	select {
 	case err := <-errCh:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -20,7 +19,6 @@ const (
 type Config struct {
 	GRPCAddr         string
 	Namespace        string
-	DisableZiti      bool
 	ZitiIdentityFile string
 	ZitiServiceName  string
 	StorageClass     *string
@@ -38,18 +36,11 @@ func Load() (Config, error) {
 	if cfg.Namespace == "" {
 		return Config{}, fmt.Errorf("KUBE_NAMESPACE is required")
 	}
-	if value, ok := os.LookupEnv("DISABLE_ZITI"); ok {
-		disableZiti, err := strconv.ParseBool(strings.TrimSpace(value))
-		if err != nil {
-			return Config{}, fmt.Errorf("invalid DISABLE_ZITI: %w", err)
-		}
-		cfg.DisableZiti = disableZiti
-	}
 
 	cfg.ZitiIdentityFile = strings.TrimSpace(os.Getenv("ZITI_IDENTITY_FILE"))
 	cfg.ZitiServiceName = readEnv("ZITI_SERVICE_NAME", defaultZitiServiceName)
-	if !cfg.DisableZiti && cfg.ZitiIdentityFile == "" {
-		return Config{}, fmt.Errorf("ZITI_IDENTITY_FILE is required unless DISABLE_ZITI is true")
+	if cfg.ZitiIdentityFile == "" {
+		return Config{}, fmt.Errorf("ZITI_IDENTITY_FILE is required")
 	}
 
 	storageClass := strings.TrimSpace(os.Getenv("PVC_STORAGE_CLASS"))


### PR DESCRIPTION
## Summary
- remove DISABLE_ZITI handling from config, Helm values, and startup
- require ZITI_IDENTITY_FILE in config and always start OpenZiti listener
- keep TCP listener for health checks

## Testing
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...

Fixes #4