### PR TITLE
test: add runner e2e suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/openziti/sdk-golang v0.24.1
+	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.1
 	google.golang.org/grpc v1.67.0
 	google.golang.org/protobuf v1.36.11
@@ -85,6 +86,7 @@ require (
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,9 +1,0 @@
-//go:build e2e
-
-package e2e
-
-import "testing"
-
-func TestPlaceholder(t *testing.T) {
-	t.Skip("no e2e tests implemented")
-}

--- a/test/e2e/errors_test.go
+++ b/test/e2e/errors_test.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestErrors(t *testing.T) {
+	t.Run("start_workload_missing_image", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		_, err := runnerClient.StartWorkload(ctx, &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{Image: ""},
+		})
+		requireGRPCCode(t, err, codes.InvalidArgument)
+	})
+
+	t.Run("inspect_nonexistent_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		_, err := runnerClient.InspectWorkload(ctx, &runnerv1.InspectWorkloadRequest{WorkloadId: "missing-workload"})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+
+	t.Run("exec_on_nonexistent_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		stream, err := runnerClient.Exec(ctx)
+		require.NoError(t, err)
+
+		err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Start{Start: &runnerv1.ExecStartRequest{
+			TargetId:    "missing-workload",
+			CommandArgv: []string{"echo", "hi"},
+		}}})
+		require.NoError(t, err)
+
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		errResp := resp.GetError()
+		require.NotNil(t, errResp)
+		require.Equal(t, "exec_start_failed", errResp.GetCode())
+	})
+
+	t.Run("remove_nonexistent_volume", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		_, err := runnerClient.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: "missing-volume"})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+}

--- a/test/e2e/exec_test.go
+++ b/test/e2e/exec_test.go
@@ -1,0 +1,162 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestExec(t *testing.T) {
+	t.Run("basic_command", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startRunningWorkload(t, ctx)
+		result := collectExecOutput(t, ctx, &runnerv1.ExecStartRequest{
+			TargetId:    workloadID,
+			CommandArgv: []string{"echo", "hello-e2e"},
+		})
+
+		require.NotNil(t, result.exit)
+		require.Equal(t, int32(0), result.exit.GetExitCode())
+		require.Contains(t, result.stdout, "hello-e2e")
+	})
+
+	t.Run("shell_command", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startRunningWorkload(t, ctx)
+		result := collectExecOutput(t, ctx, &runnerv1.ExecStartRequest{
+			TargetId:     workloadID,
+			CommandShell: "echo out; echo err 1>&2",
+			Options:      &runnerv1.ExecOptions{SeparateStderr: true},
+			RequestId:    uniqueName("exec"),
+		})
+
+		require.NotNil(t, result.exit)
+		require.Contains(t, result.stdout, "out")
+		require.Contains(t, result.stderr, "err")
+	})
+
+	t.Run("nonzero_exit_code", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startRunningWorkload(t, ctx)
+		result := collectExecOutput(t, ctx, &runnerv1.ExecStartRequest{
+			TargetId:     workloadID,
+			CommandShell: "exit 42",
+		})
+
+		require.NotNil(t, result.exit)
+		require.Equal(t, int32(42), result.exit.GetExitCode())
+	})
+
+	t.Run("stdin_and_eof", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startRunningWorkload(t, ctx)
+		payload := "stdin-e2e\n"
+		result := collectExecOutput(
+			t,
+			ctx,
+			&runnerv1.ExecStartRequest{
+				TargetId:    workloadID,
+				CommandArgv: []string{"cat"},
+			},
+			&runnerv1.ExecStdin{Data: []byte(payload)},
+			&runnerv1.ExecStdin{Eof: true},
+		)
+
+		require.NotNil(t, result.exit)
+		require.Equal(t, payload, result.stdout)
+	})
+
+	t.Run("cancel_execution", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startRunningWorkload(t, ctx)
+		stream, err := runnerClient.Exec(ctx)
+		require.NoError(t, err)
+
+		err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Start{Start: &runnerv1.ExecStartRequest{
+			TargetId:    workloadID,
+			CommandArgv: []string{"sleep", "300"},
+		}}})
+		require.NoError(t, err)
+
+		var execID string
+		for {
+			resp, err := stream.Recv()
+			require.NoError(t, err)
+			if started := resp.GetStarted(); started != nil {
+				execID = started.GetExecutionId()
+				break
+			}
+			if errResp := resp.GetError(); errResp != nil {
+				t.Fatalf("exec error: %s", errResp.GetMessage())
+			}
+		}
+
+		require.NotEmpty(t, execID)
+		cancelResp, err := runnerClient.CancelExecution(ctx, &runnerv1.CancelExecutionRequest{
+			ExecutionId: execID,
+			Force:       true,
+		})
+		require.NoError(t, err)
+		require.True(t, cancelResp.GetCancelled())
+
+		var exit *runnerv1.ExecExit
+		for {
+			resp, err := stream.Recv()
+			require.NoError(t, err)
+			if exitResp := resp.GetExit(); exitResp != nil {
+				exit = exitResp
+				break
+			}
+			if errResp := resp.GetError(); errResp != nil {
+				t.Fatalf("exec error: %s", errResp.GetMessage())
+			}
+		}
+
+		require.NotNil(t, exit)
+		require.Equal(t, runnerv1.ExecExitReason_EXEC_EXIT_REASON_CANCELLED, exit.GetReason())
+	})
+
+	t.Run("workdir_and_env", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startRunningWorkload(t, ctx)
+		result := collectExecOutput(t, ctx, &runnerv1.ExecStartRequest{
+			TargetId:     workloadID,
+			CommandShell: "pwd; echo $FOO",
+			Options: &runnerv1.ExecOptions{
+				Workdir: "/tmp",
+				Env: []*runnerv1.EnvVar{{
+					Name:  "FOO",
+					Value: "bar",
+				}},
+			},
+		})
+
+		require.NotNil(t, result.exit)
+		require.Contains(t, result.stdout, "/tmp")
+		require.Contains(t, result.stdout, "bar")
+	})
+}
+
+func startRunningWorkload(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	workloadID := startWorkload(t, ctx, sleepWorkloadRequest())
+	waitRunning(t, ctx, workloadID)
+	return workloadID
+}

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -1,0 +1,251 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+const (
+	defaultWorkloadImage = "alpine:3.19"
+	perTestTimeout       = 120 * time.Second
+	waitRunningTimeout   = 60 * time.Second
+	waitGoneTimeout      = 30 * time.Second
+	cleanupTimeout       = 30 * time.Second
+	pollInterval         = 2 * time.Second
+)
+
+type execResult struct {
+	stdout  string
+	stderr  string
+	exit    *runnerv1.ExecExit
+	started *runnerv1.ExecStarted
+}
+
+func testContext(t *testing.T) (context.Context, context.CancelFunc) {
+	t.Helper()
+	return context.WithTimeout(context.Background(), perTestTimeout)
+}
+
+func startWorkload(t *testing.T, ctx context.Context, req *runnerv1.StartWorkloadRequest) string {
+	t.Helper()
+	resp := startWorkloadWithCleanup(t, ctx, req)
+	return resp.GetId()
+}
+
+func startWorkloadWithCleanup(t *testing.T, ctx context.Context, req *runnerv1.StartWorkloadRequest) *runnerv1.StartWorkloadResponse {
+	t.Helper()
+	resp, err := runnerClient.StartWorkload(ctx, req)
+	require.NoError(t, err)
+
+	workloadID := strings.TrimSpace(resp.GetId())
+	require.NotEmpty(t, workloadID)
+	registerWorkloadCleanup(t, workloadID)
+
+	return resp
+}
+
+func registerWorkloadCleanup(t *testing.T, workloadID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), cleanupTimeout)
+		defer cancel()
+		_, err := runnerClient.RemoveWorkload(ctx, &runnerv1.RemoveWorkloadRequest{
+			WorkloadId:    workloadID,
+			Force:         true,
+			RemoveVolumes: true,
+		})
+		if err == nil {
+			return
+		}
+		if status.Code(err) == codes.NotFound {
+			return
+		}
+		t.Errorf("cleanup remove workload %s: %v", workloadID, err)
+	})
+}
+
+func waitRunning(t *testing.T, ctx context.Context, workloadID string) *runnerv1.InspectWorkloadResponse {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, waitRunningTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		resp, err := runnerClient.InspectWorkload(waitCtx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
+		if err == nil {
+			if resp.GetStateRunning() {
+				return resp
+			}
+		} else if status.Code(err) != codes.NotFound {
+			require.NoError(t, err)
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("workload %s not running: %v", workloadID, waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitGone(t *testing.T, ctx context.Context, workloadID string) {
+	t.Helper()
+	waitCtx, cancel := context.WithTimeout(ctx, waitGoneTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		_, err := runnerClient.InspectWorkload(waitCtx, &runnerv1.InspectWorkloadRequest{WorkloadId: workloadID})
+		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				return
+			}
+			require.NoError(t, err)
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf("workload %s still present: %v", workloadID, waitCtx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+func buildTarWithFile(name, content string) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}); err != nil {
+		panic(err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		panic(err)
+	}
+	if err := tw.Close(); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func collectExecOutput(t *testing.T, ctx context.Context, start *runnerv1.ExecStartRequest, stdin ...*runnerv1.ExecStdin) execResult {
+	t.Helper()
+	stream, err := runnerClient.Exec(ctx)
+	require.NoError(t, err)
+
+	err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Start{Start: start}})
+	require.NoError(t, err)
+
+	for _, input := range stdin {
+		if input == nil {
+			continue
+		}
+		err = stream.Send(&runnerv1.ExecRequest{Msg: &runnerv1.ExecRequest_Stdin{Stdin: input}})
+		require.NoError(t, err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var started *runnerv1.ExecStarted
+
+	for {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+
+		switch event := resp.GetEvent().(type) {
+		case *runnerv1.ExecResponse_Started:
+			started = event.Started
+		case *runnerv1.ExecResponse_Stdout:
+			stdout.Write(event.Stdout.GetData())
+		case *runnerv1.ExecResponse_Stderr:
+			stderr.Write(event.Stderr.GetData())
+		case *runnerv1.ExecResponse_Exit:
+			return execResult{
+				stdout:  stdout.String(),
+				stderr:  stderr.String(),
+				exit:    event.Exit,
+				started: started,
+			}
+		case *runnerv1.ExecResponse_Error:
+			t.Fatalf("exec error: %s", event.Error.GetMessage())
+		default:
+			t.Fatalf("unexpected exec response: %T", event)
+		}
+	}
+}
+
+func collectWorkloadLogs(t *testing.T, ctx context.Context, workloadID string, follow bool, tail uint32) string {
+	t.Helper()
+	stream, err := runnerClient.StreamWorkloadLogs(ctx, &runnerv1.StreamWorkloadLogsRequest{
+		WorkloadId: workloadID,
+		Follow:     follow,
+		Tail:       tail,
+	})
+	require.NoError(t, err)
+
+	var output bytes.Buffer
+	for {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+
+		if chunk := resp.GetChunk(); chunk != nil {
+			output.Write(chunk.GetData())
+			continue
+		}
+		if resp.GetEnd() != nil {
+			return output.String()
+		}
+		if errResp := resp.GetError(); errResp != nil {
+			t.Fatalf("log stream error: %s", errResp.GetMessage())
+		}
+	}
+}
+
+func requireGRPCCode(t *testing.T, err error, code codes.Code) {
+	t.Helper()
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, code, st.Code())
+}
+
+func sleepWorkloadRequest(cmd ...string) *runnerv1.StartWorkloadRequest {
+	args := cmd
+	if len(args) == 0 {
+		args = []string{"sleep", "300"}
+	}
+	return &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{
+			Image: defaultWorkloadImage,
+			Cmd:   append([]string{}, args...),
+		},
+	}
+}
+
+func uniqueName(prefix string) string {
+	base := strings.Trim(prefix, "- ")
+	if base == "" {
+		base = "e2e"
+	}
+	return strings.ToLower(fmt.Sprintf("%s-%s", base, uuid.NewString()))
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,55 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	defaultRunnerAddr = "k8s-runner:50051"
+	dialTimeout       = 20 * time.Second
+)
+
+var (
+	runnerClient runnerv1.RunnerServiceClient
+	runnerConn   *grpc.ClientConn
+)
+
+func TestMain(m *testing.M) {
+	addr := os.Getenv("K8S_RUNNER_ADDR")
+	if addr == "" {
+		addr = defaultRunnerAddr
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(
+		ctx,
+		addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to connect to %s: %v\n", addr, err)
+		os.Exit(1)
+	}
+
+	runnerConn = conn
+	runnerClient = runnerv1.NewRunnerServiceClient(conn)
+
+	exitCode := m.Run()
+	if err := conn.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to close gRPC connection: %v\n", err)
+	}
+	os.Exit(exitCode)
+}

--- a/test/e2e/storage_test.go
+++ b/test/e2e/storage_test.go
@@ -1,0 +1,41 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestPutArchive(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	workloadID := startWorkload(t, ctx, &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{
+			Image:      defaultWorkloadImage,
+			Entrypoint: "/bin/sh",
+			Cmd:        []string{"-c", "mkdir -p /tmp/e2e && sleep 300"},
+		},
+	})
+	waitRunning(t, ctx, workloadID)
+
+	tarPayload := buildTarWithFile("hello.txt", "hello-storage")
+	_, err := runnerClient.PutArchive(ctx, &runnerv1.PutArchiveRequest{
+		WorkloadId: workloadID,
+		Path:       "/tmp/e2e",
+		TarPayload: tarPayload,
+	})
+	require.NoError(t, err)
+
+	result := collectExecOutput(t, ctx, &runnerv1.ExecStartRequest{
+		TargetId:    workloadID,
+		CommandArgv: []string{"cat", "/tmp/e2e/hello.txt"},
+	})
+	require.NotNil(t, result.exit)
+	require.Equal(t, int32(0), result.exit.GetExitCode())
+	require.Contains(t, result.stdout, "hello-storage")
+}

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -1,0 +1,82 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestStreaming(t *testing.T) {
+	t.Run("logs_follow", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{
+				Image:      defaultWorkloadImage,
+				Entrypoint: "/bin/sh",
+				Cmd:        []string{"-c", "echo follow-1; echo follow-2; sleep 2"},
+			},
+		}
+		workloadID := startWorkload(t, ctx, req)
+		waitRunning(t, ctx, workloadID)
+
+		logs := collectWorkloadLogs(t, ctx, workloadID, true, 0)
+		require.Contains(t, logs, "follow-1")
+		require.Contains(t, logs, "follow-2")
+	})
+
+	t.Run("logs_tail", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{
+				Image:      defaultWorkloadImage,
+				Entrypoint: "/bin/sh",
+				Cmd:        []string{"-c", "echo line-1; echo line-2; echo line-3; echo line-4; sleep 2"},
+			},
+		}
+		workloadID := startWorkload(t, ctx, req)
+		waitRunning(t, ctx, workloadID)
+
+		logs := collectWorkloadLogs(t, ctx, workloadID, false, 2)
+		require.Contains(t, logs, "line-3")
+		require.Contains(t, logs, "line-4")
+		require.NotContains(t, logs, "line-1")
+	})
+}
+
+func TestStreamEvents(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	streamCtx, streamCancel := context.WithTimeout(ctx, waitRunningTimeout)
+	t.Cleanup(streamCancel)
+
+	stream, err := runnerClient.StreamEvents(streamCtx, &runnerv1.StreamEventsRequest{})
+	require.NoError(t, err)
+
+	workloadID := startWorkload(t, ctx, sleepWorkloadRequest())
+	waitRunning(t, ctx, workloadID)
+
+	for {
+		resp, err := stream.Recv()
+		require.NoError(t, err)
+		if data := resp.GetData(); data != nil {
+			if strings.Contains(data.GetJson(), workloadID) {
+				return
+			}
+			continue
+		}
+		if errResp := resp.GetError(); errResp != nil {
+			t.Fatalf("events stream error: %s", errResp.GetMessage())
+		}
+	}
+}

--- a/test/e2e/volume_test.go
+++ b/test/e2e/volume_test.go
@@ -1,0 +1,59 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestVolumeQueries(t *testing.T) {
+	t.Run("list_workloads_by_volume", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		volumeName := uniqueName("volume")
+		workloadID := startWorkload(t, ctx, volumeWorkloadRequest(volumeName))
+		waitRunning(t, ctx, workloadID)
+
+		resp, err := runnerClient.ListWorkloadsByVolume(ctx, &runnerv1.ListWorkloadsByVolumeRequest{VolumeName: volumeName})
+		require.NoError(t, err)
+		require.Contains(t, resp.GetTargetIds(), workloadID)
+	})
+
+	t.Run("remove_volume", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		volumeName := uniqueName("volume")
+		workloadID := startWorkload(t, ctx, volumeWorkloadRequest(volumeName))
+		waitRunning(t, ctx, workloadID)
+
+		_, err := runnerClient.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{WorkloadId: workloadID, TimeoutSec: 1})
+		require.NoError(t, err)
+		waitGone(t, ctx, workloadID)
+
+		_, err = runnerClient.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: volumeName})
+		require.NoError(t, err)
+		_, err = runnerClient.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: volumeName})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+}
+
+func volumeWorkloadRequest(volumeName string) *runnerv1.StartWorkloadRequest {
+	req := sleepWorkloadRequest()
+	req.Volumes = []*runnerv1.VolumeSpec{{
+		Name:           "data",
+		Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+		PersistentName: volumeName,
+	}}
+	req.Main.Mounts = []*runnerv1.VolumeMount{{
+		Volume:    "data",
+		MountPath: "/data",
+	}}
+	return req
+}

--- a/test/e2e/workload_test.go
+++ b/test/e2e/workload_test.go
@@ -1,0 +1,165 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestReady(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	resp, err := runnerClient.Ready(ctx, &runnerv1.ReadyRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "ok", resp.GetStatus())
+}
+
+func TestWorkloadLifecycle(t *testing.T) {
+	t.Run("start_and_inspect", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startWorkload(t, ctx, sleepWorkloadRequest())
+		resp := waitRunning(t, ctx, workloadID)
+
+		require.Equal(t, workloadID, resp.GetId())
+		require.Equal(t, workloadID, resp.GetName())
+		require.Equal(t, defaultWorkloadImage, resp.GetConfigImage())
+		require.NotEmpty(t, resp.GetImage())
+		require.True(t, resp.GetStateRunning())
+		require.NotEmpty(t, resp.GetStateStatus())
+		require.Equal(t, "k8s-runner", resp.GetConfigLabels()["app.kubernetes.io/managed-by"])
+		require.Equal(t, workloadID, resp.GetConfigLabels()["agyn.io/workload-id"])
+		require.Empty(t, resp.GetMounts())
+	})
+
+	t.Run("start_with_env_and_workdir", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := &runnerv1.StartWorkloadRequest{
+			Main: &runnerv1.ContainerSpec{
+				Image:      defaultWorkloadImage,
+				Entrypoint: "/bin/sh",
+				Cmd:        []string{"-c", "echo \"$FOO\"; pwd; sleep 5"},
+				Env: []*runnerv1.EnvVar{{
+					Name:  "FOO",
+					Value: "hello-e2e",
+				}},
+				WorkingDir: "/tmp",
+			},
+		}
+
+		workloadID := startWorkload(t, ctx, req)
+		waitRunning(t, ctx, workloadID)
+
+		logs := collectWorkloadLogs(t, ctx, workloadID, false, 0)
+		require.Contains(t, logs, "hello-e2e")
+		require.Contains(t, logs, "/tmp")
+	})
+
+	t.Run("start_with_sidecars", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := sleepWorkloadRequest()
+		req.Sidecars = []*runnerv1.ContainerSpec{{
+			Name:  "sidecar",
+			Image: defaultWorkloadImage,
+			Cmd:   []string{"sleep", "300"},
+		}}
+		resp := startWorkloadWithCleanup(t, ctx, req)
+		waitRunning(t, ctx, resp.GetId())
+
+		sidecars := resp.GetContainers().GetSidecars()
+		require.Len(t, sidecars, 1)
+		require.Equal(t, "sidecar", sidecars[0].GetName())
+		require.NotEmpty(t, sidecars[0].GetId())
+	})
+
+	t.Run("start_with_custom_labels", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		req := sleepWorkloadRequest()
+		req.AdditionalProperties = map[string]string{
+			"label.team": "platform",
+		}
+		workloadID := startWorkload(t, ctx, req)
+		waitRunning(t, ctx, workloadID)
+
+		labelsResp, err := runnerClient.GetWorkloadLabels(ctx, &runnerv1.GetWorkloadLabelsRequest{WorkloadId: workloadID})
+		require.NoError(t, err)
+		require.Equal(t, "platform", labelsResp.GetLabels()["team"])
+
+		findResp, err := runnerClient.FindWorkloadsByLabels(ctx, &runnerv1.FindWorkloadsByLabelsRequest{
+			Labels: map[string]string{"team": "platform"},
+			All:    true,
+		})
+		require.NoError(t, err)
+		require.Contains(t, findResp.GetTargetIds(), workloadID)
+	})
+
+	t.Run("touch_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startWorkload(t, ctx, sleepWorkloadRequest())
+		waitRunning(t, ctx, workloadID)
+
+		_, err := runnerClient.TouchWorkload(ctx, &runnerv1.TouchWorkloadRequest{WorkloadId: workloadID})
+		require.NoError(t, err)
+	})
+
+	t.Run("stop_workload", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		workloadID := startWorkload(t, ctx, sleepWorkloadRequest())
+		waitRunning(t, ctx, workloadID)
+
+		_, err := runnerClient.StopWorkload(ctx, &runnerv1.StopWorkloadRequest{
+			WorkloadId: workloadID,
+			TimeoutSec: 1,
+		})
+		require.NoError(t, err)
+		waitGone(t, ctx, workloadID)
+	})
+
+	t.Run("remove_workload_with_volumes", func(t *testing.T) {
+		ctx, cancel := testContext(t)
+		t.Cleanup(cancel)
+
+		volumeName := uniqueName("volume")
+		req := sleepWorkloadRequest()
+		req.Volumes = []*runnerv1.VolumeSpec{{
+			Name:           "data",
+			Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+			PersistentName: volumeName,
+		}}
+		req.Main.Mounts = []*runnerv1.VolumeMount{{
+			Volume:    "data",
+			MountPath: "/data",
+		}}
+
+		workloadID := startWorkload(t, ctx, req)
+		waitRunning(t, ctx, workloadID)
+
+		_, err := runnerClient.RemoveWorkload(ctx, &runnerv1.RemoveWorkloadRequest{
+			WorkloadId:    workloadID,
+			Force:         true,
+			RemoveVolumes: true,
+		})
+		require.NoError(t, err)
+		waitGone(t, ctx, workloadID)
+
+		_, err = runnerClient.RemoveVolume(ctx, &runnerv1.RemoveVolumeRequest{VolumeName: volumeName})
+		requireGRPCCode(t, err, codes.NotFound)
+	})
+}


### PR DESCRIPTION
## Summary
- replace the placeholder e2e test with a full RunnerService suite
- add e2e helpers for workload lifecycle, exec, streaming, storage, and volume checks
- add testify dependency for assertions

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet -tags e2e ./test/e2e/

Fixes #6