### PR TITLE
fix: resolve 2 e2e test failures in server code

### DIFF
--- a/internal/server/storage.go
+++ b/internal/server/storage.go
@@ -82,6 +82,14 @@ func (s *Server) RemoveVolume(ctx context.Context, req *runnerv1.RemoveVolumeReq
 		return nil, status.Error(codes.InvalidArgument, "volume_name_required")
 	}
 
+	pvc, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).Get(ctx, volumeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, grpcErrorFromKube(s.logger, err, codes.NotFound)
+	}
+	if pvc.DeletionTimestamp != nil {
+		return nil, status.Error(codes.NotFound, "resource not found")
+	}
+
 	if err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).Delete(ctx, volumeName, metav1.DeleteOptions{}); err != nil {
 		return nil, grpcErrorFromKube(s.logger, err, codes.Internal)
 	}

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -471,8 +471,6 @@ func mountsForPod(pod *corev1.Pod, mainContainerName string) []*runnerv1.TargetM
 			volumeSources[volume.Name] = volumeInfo{mountType: "pvc", source: volume.PersistentVolumeClaim.ClaimName}
 		case volume.EmptyDir != nil:
 			volumeSources[volume.Name] = volumeInfo{mountType: "emptydir", source: volume.Name}
-		default:
-			volumeSources[volume.Name] = volumeInfo{mountType: "unknown", source: volume.Name}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes 2 of 22 e2e tests that fail in CI (20 pass, 2 fail).

### Fix 1 — `TestWorkloadLifecycle/start_and_inspect`

**Root cause:** `mountsForPod` in `internal/server/workload.go` had a `default` branch that mapped every non-PVC/non-EmptyDir volume to `type: "unknown"`. Kubernetes auto-mounts a service account token as a `Projected` volume (`kube-api-access-*`) on every pod. This volume hit the `default` branch and appeared in the `InspectWorkload` response.

The test correctly asserts `require.Empty(t, resp.GetMounts())` because no user-defined volumes were requested via `StartWorkload`. Docker-based runners never expose these infrastructure mounts either.

**Fix:** Remove the `default` branch from the volume type switch. Only `PersistentVolumeClaim` and `EmptyDir` — the two types `buildVolumes` creates — are included in the `volumeSources` map. The SA token volume mount is now silently skipped via the existing `if !ok { continue }` guard.

### Fix 2 — `TestVolumeQueries/remove_volume`

**Root cause:** The test calls `RemoveVolume` twice on the same PVC. The second call should return `codes.NotFound`, but returns `nil`. This happens because Kubernetes PVC deletion is two-phase: the first `Delete()` sets `deletionTimestamp` and the `kubernetes.io/pvc-protection` finalizer keeps the resource in `Terminating` state. A second `Delete()` call while the PVC is still terminating succeeds silently — the API server accepts it because the resource still exists in etcd.

**Fix:** Add a `Get` check before `Delete` in `RemoveVolume`:
- If the PVC doesn't exist → `grpcErrorFromKube` maps to `codes.NotFound`
- If the PVC exists but has `DeletionTimestamp != nil` (already terminating) → return `codes.NotFound`
- Otherwise → proceed with `Delete` as before

## Testing

- `CGO_ENABLED=0 go build ./...` ✅
- `CGO_ENABLED=0 go vet ./...` ✅
- `CGO_ENABLED=0 go test ./...` ✅ (1 passed, 0 failed)
- The 2 failing e2e tests should now pass in CI