### PR TITLE
fix(chart): join service-base includes with YAML document separators

### DIFF
--- a/charts/k8s-runner/templates/service-base.yaml
+++ b/charts/k8s-runner/templates/service-base.yaml
@@ -1,15 +1,15 @@
-{{- include "service-base.rbac" . }}
----
-{{- include "service-base.serviceAccount" . }}
----
-{{- include "service-base.service" . }}
----
-{{- include "service-base.deployment" . }}
----
-{{- include "service-base.hpa" . }}
----
-{{- include "service-base.ingress" . }}
----
-{{- include "service-base.pdb" . }}
----
-{{- include "service-base.metrics" . }}
+{{- $rbac := include "service-base.rbac" . -}}
+{{- $sa := include "service-base.serviceAccount" . -}}
+{{- $svc := include "service-base.service" . -}}
+{{- $deploy := include "service-base.deployment" . -}}
+{{- $hpa := include "service-base.hpa" . -}}
+{{- $ingress := include "service-base.ingress" . -}}
+{{- $pdb := include "service-base.pdb" . -}}
+{{- $metrics := include "service-base.metrics" . -}}
+{{- $parts := list -}}
+{{- range (list $rbac $sa $svc $deploy $hpa $ingress $pdb $metrics) -}}
+  {{- if . -}}
+    {{- $parts = append $parts . -}}
+  {{- end -}}
+{{- end -}}
+{{ join "\n---\n" $parts }}


### PR DESCRIPTION
## Summary

Fixes the `helm lint` failure that blocked the `v0.1.0` release:

```
[ERROR] templates/service-base.yaml: unable to parse YAML: invalid Yaml document separator: apiVersion: v1
```

## Root Cause

The `service-base` library templates use `{{- end -}}` (trailing dash) which strips all trailing whitespace including the final newline. The previous `service-base.yaml` placed literal `---` YAML document separators between `include` calls:

```yaml
{{- include "service-base.rbac" . }}
---
{{- include "service-base.serviceAccount" . }}
```

Because the preceding include's output had no trailing newline, this rendered as:

```
  name: test-k8s-runner---
apiVersion: v1
```

…which is invalid YAML (`---` must be on its own line).

Additionally, when optional features are disabled (HPA, ingress, PDB, metrics), the include expands to empty, leaving `---` between empty content — also invalid.

## Fix

Capture each `include` result into a template variable, filter out empty strings (disabled features), and `join` the non-empty results with `\n---\n`. This produces clean `---` separators only between actual resources.

## Verification

```bash
helm dependency build charts/k8s-runner
helm lint charts/k8s-runner               # passes
helm lint charts/k8s-runner --strict      # passes
helm template test charts/k8s-runner      # produces valid multi-document YAML
```

Rendered resources (default values): ServiceAccount, Role, RoleBinding, Service, Deployment — no empty documents.

## Note

This same concatenation bug exists in `agynio/agent-state`, `agynio/notifications`, `agynio/threads`, and `agynio/files` (they use `{{- include ... -}}` without separators, which concatenates resources directly). Those charts passed `helm lint` on v3.14.4 but would fail on newer Helm versions. A follow-up should apply the same fix pattern to those repos.