### PR TITLE
fix: include imports in buf generate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: bufbuild/buf-setup-action@v1
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml
+        run: buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=buf /usr/local/bin/buf /usr/local/bin/buf
 COPY go.mod go.sum ./
 RUN go mod download
 COPY buf.gen.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml
+RUN buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml
 COPY . .
 ARG TARGETOS TARGETARCH
 ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -140,7 +140,7 @@ pipelines:
             [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
           done
           sleep 5
-          cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml && go test -v -count=1 -tags e2e ./test/e2e/'
+          cd /opt/app/data && buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/scripts/devspace-startup.sh
+++ b/scripts/devspace-startup.sh
@@ -4,7 +4,7 @@ set -eu
 echo "=== DevSpace startup ==="
 
 echo "Generating protobuf types..."
-buf generate buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml
+buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/ziti_management/v1 --template ./buf.gen.yaml
 
 echo "Downloading Go modules..."
 go mod download


### PR DESCRIPTION
## Summary
- add --include-imports to buf generate commands in CI, Dockerfile, DevSpace pipeline, and startup script

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go build ./...

Refs #16