### PR TITLE
chore: bump chart version to 0.2.0

### DIFF
--- a/charts/k8s-runner/Chart.yaml
+++ b/charts/k8s-runner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k8s-runner
 description: Helm chart for the agynio k8s-runner gRPC service
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/agynio/k8s-runner
 sources:
   - https://github.com/agynio/k8s-runner


### PR DESCRIPTION
Bump k8s-runner Helm chart version and appVersion from 0.1.0 to 0.2.0.

Changes since v0.1.0:
- feat: add init container support (#15)
- fix: include imports in buf generate (#17)
- feat(ziti): request service identity (#13)

This release is needed for the agents-orchestrator E2E CI — the orchestrator now sends `StartWorkloadRequest` with init containers, which requires k8s-runner ≥ 0.2.0.