### PR TITLE
feat: map container security options

### DIFF
--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -458,11 +458,11 @@ func buildContainer(spec *runnerv1.ContainerSpec, fallbackName string, volumeLoo
 	if len(spec.RequiredCapabilities) > 0 {
 		caps := make([]corev1.Capability, 0, len(spec.RequiredCapabilities))
 		for _, capability := range spec.RequiredCapabilities {
-			name := strings.TrimSpace(capability)
-			if name == "" {
+			capName := strings.TrimSpace(capability)
+			if capName == "" {
 				continue
 			}
-			caps = append(caps, corev1.Capability(name))
+			caps = append(caps, corev1.Capability(capName))
 		}
 		if len(caps) > 0 {
 			container.SecurityContext = &corev1.SecurityContext{

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -127,6 +127,20 @@ func TestBuildContainerOmitsSecurityContextWithoutRequiredCapabilities(t *testin
 	}
 }
 
+func TestBuildContainerOmitsSecurityContextForWhitespaceCapabilities(t *testing.T) {
+	container, err := buildContainer(&runnerv1.ContainerSpec{
+		Name:                 "main",
+		Image:                "busybox",
+		RequiredCapabilities: []string{" ", ""},
+	}, "main", map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("buildContainer returned error: %v", err)
+	}
+	if container.SecurityContext != nil {
+		t.Fatalf("expected no security context when capabilities are whitespace-only")
+	}
+}
+
 func TestBuildContainersRejectsDuplicateNames(t *testing.T) {
 	req := &runnerv1.StartWorkloadRequest{
 		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},


### PR DESCRIPTION
## Summary
- map required container capabilities into pod security context
- allow init containers to set restart policy Always via additional properties
- add TODO note for future DNS config mapping and cover new behavior with tests

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go build ./...

#19