### PR TITLE
chore: align release Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=k8s-runner
           cache-to: type=gha,scope=k8s-runner,mode=max
-          build-args: GO_VERSION=1.22
+          build-args: GO_VERSION=1.25
 
       - name: Verify multi-arch manifest
         run: |


### PR DESCRIPTION
## Summary
- align release workflow build-args with Go 1.25.x

## Testing
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go vet -tags e2e ./test/e2e/
- CGO_ENABLED=0 go test ./...

Refs #27