### PR TITLE
fix(config): default runner id uuid

### DIFF
--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -90,7 +90,8 @@ env:
   - name: KUBE_NAMESPACE
     value: "agyn-workloads"
   - name: RUNNER_ID
-    value: "00000000-0000-0000-0000-6b38732d7275"
+    # Placeholder — override with the UUID assigned by the bootstrap process.
+    value: "439e0da2-88cd-46d7-bb9c-56c723c15606"
   - name: PVC_STORAGE_SIZE
     value: "10Gi"
   - name: ZITI_ENABLED

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,6 @@ const (
 	defaultZitiServiceName          = "runner"
 	defaultStorageSize              = "10Gi"
 	defaultLogLevel                 = "info"
-	defaultRunnerID                 = "00000000-0000-0000-0000-6b38732d7275"
 )
 
 // Config captures runtime configuration derived from the environment.
@@ -47,7 +46,7 @@ func Load() (Config, error) {
 
 	cfg.RunnerID = strings.TrimSpace(os.Getenv("RUNNER_ID"))
 	if cfg.RunnerID == "" {
-		cfg.RunnerID = defaultRunnerID
+		return Config{}, fmt.Errorf("RUNNER_ID is required")
 	}
 
 	var err error


### PR DESCRIPTION
## Summary
- require RUNNER_ID in config loading (no default fallback)
- set Helm RUNNER_ID placeholder to a UUID v4 with guidance to override

## Testing
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...

Ref #23