### PR TITLE
Remove k8s runner identity env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,6 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Bootstrap cluster
-        env:
-          # Temporary: pre-provisioned runner identity ID from bootstrap; remove after enrollment migration.
-          TF_VAR_k8s_runner_identity_id: 439e0da2-88cd-46d7-bb9c-56c723c15606
         run: cd bootstrap && ./apply.sh -y
 
       - name: Configure kubeconfig


### PR DESCRIPTION
## Summary
- drop TF_VAR_k8s_runner_identity_id from bootstrap step

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet -tags e2e ./test/e2e/

Refs #222