### PR TITLE
fix(chart): add secrets RBAC for image pull credentials

### DIFF
--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -42,6 +42,9 @@ rbac:
       resources: ["persistentvolumeclaims"]
       verbs: ["get", "list", "create", "delete"]
     - apiGroups: [""]
+      resources: ["secrets"]
+      verbs: ["create", "delete"]
+    - apiGroups: [""]
       resources: ["events"]
       verbs: ["get", "list", "watch"]
 


### PR DESCRIPTION
## Summary

The `v0.8.0` release added image pull credential support which creates and deletes k8s `Secret` objects for docker config JSON. However, the Helm chart's RBAC rules were not updated to include `secrets` permissions, causing `Forbidden` errors when the runner tries to create image pull secrets.

## Changes

- `charts/k8s-runner/values.yaml`: Add `secrets` resource with `create` and `delete` verbs to default RBAC rules

## Testing

Verified against agents-orchestrator e2e where `TestImagePullSecretAttachedToPod` fails with `PermissionDenied` due to missing secrets RBAC.