### PR TITLE
fix(server): include kube error details

### DIFF
--- a/charts/k8s-runner/Chart.yaml
+++ b/charts/k8s-runner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k8s-runner
 description: Helm chart for the agynio k8s-runner gRPC service
 type: application
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.9.0
+appVersion: 0.9.0
 home: https://github.com/agynio/k8s-runner
 sources:
   - https://github.com/agynio/k8s-runner

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"errors"
+	"strings"
+
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,20 +18,43 @@ func grpcErrorFromKube(logger *zap.Logger, err error, fallback codes.Code) error
 		logger.Error("kubernetes api error", zap.Error(err))
 	}
 
+	message := kubeStatusMessage(err)
+
 	switch {
 	case apierrors.IsNotFound(err):
-		return status.Error(codes.NotFound, "resource not found")
+		return status.Error(codes.NotFound, formatKubeError("resource not found", message))
 	case apierrors.IsAlreadyExists(err):
-		return status.Error(codes.AlreadyExists, "resource already exists")
+		return status.Error(codes.AlreadyExists, formatKubeError("resource already exists", message))
 	case apierrors.IsInvalid(err):
-		return status.Error(codes.InvalidArgument, "invalid kubernetes request")
+		return status.Error(codes.InvalidArgument, formatKubeError("invalid kubernetes request", message))
 	case apierrors.IsUnauthorized(err):
-		return status.Error(codes.Unauthenticated, "unauthenticated")
+		return status.Error(codes.Unauthenticated, formatKubeError("unauthenticated", message))
 	case apierrors.IsForbidden(err):
-		return status.Error(codes.PermissionDenied, "permission denied")
+		return status.Error(codes.PermissionDenied, formatKubeError("permission denied", message))
 	case apierrors.IsConflict(err):
-		return status.Error(codes.Aborted, "resource conflict")
+		return status.Error(codes.Aborted, formatKubeError("resource conflict", message))
 	default:
-		return status.Error(fallback, "kubernetes request failed")
+		return status.Error(fallback, formatKubeError("kubernetes request failed", message))
 	}
+}
+
+func formatKubeError(base, detail string) string {
+	if detail == "" {
+		return base
+	}
+	return base + ": " + detail
+}
+
+func kubeStatusMessage(err error) string {
+	var apiStatus apierrors.APIStatus
+	if !errors.As(err, &apiStatus) {
+		return ""
+	}
+
+	message := strings.TrimSpace(apiStatus.Status().Message)
+	if message == "" {
+		return ""
+	}
+
+	return message
 }

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -19,6 +19,9 @@ func grpcErrorFromKube(logger *zap.Logger, err error, fallback codes.Code) error
 	}
 
 	message := kubeStatusMessage(err)
+	if message == "" {
+		message = strings.TrimSpace(err.Error())
+	}
 
 	switch {
 	case apierrors.IsNotFound(err):

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGrpcErrorFromKubeIncludesStatusDetail(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code codes.Code
+		base string
+	}{
+		{
+			name: "not_found",
+			err:  apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "pod-1"),
+			code: codes.NotFound,
+			base: "resource not found",
+		},
+		{
+			name: "forbidden",
+			err:  apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod-1", errors.New("no access")),
+			code: codes.PermissionDenied,
+			base: "permission denied",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := grpcErrorFromKube(nil, test.err, codes.Internal)
+			st, ok := status.FromError(got)
+			if !ok {
+				t.Fatalf("expected grpc status error")
+			}
+			if st.Code() != test.code {
+				t.Fatalf("expected code %s, got %s", test.code, st.Code())
+			}
+			apiStatus, ok := test.err.(apierrors.APIStatus)
+			if !ok {
+				t.Fatalf("expected api status error")
+			}
+			detail := strings.TrimSpace(apiStatus.Status().Message)
+			if detail == "" {
+				t.Fatalf("expected status message detail")
+			}
+			expected := test.base + ": " + detail
+			if st.Message() != expected {
+				t.Fatalf("expected message %q, got %q", expected, st.Message())
+			}
+		})
+	}
+}
+
+func TestGrpcErrorFromKubeFallbackMessage(t *testing.T) {
+	got := grpcErrorFromKube(nil, errors.New("boom"), codes.Internal)
+	st, ok := status.FromError(got)
+	if !ok {
+		t.Fatalf("expected grpc status error")
+	}
+	if st.Code() != codes.Internal {
+		t.Fatalf("expected code %s, got %s", codes.Internal, st.Code())
+	}
+	if st.Message() != "kubernetes request failed" {
+		t.Fatalf("expected fallback message, got %q", st.Message())
+	}
+}
+
+func TestGrpcErrorFromKubeNil(t *testing.T) {
+	if err := grpcErrorFromKube(nil, nil, codes.Internal); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}

--- a/internal/server/errors_test.go
+++ b/internal/server/errors_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestGrpcErrorFromKubeIncludesStatusDetail(t *testing.T) {
@@ -25,10 +26,38 @@ func TestGrpcErrorFromKubeIncludesStatusDetail(t *testing.T) {
 			base: "resource not found",
 		},
 		{
+			name: "already_exists",
+			err:  apierrors.NewAlreadyExists(schema.GroupResource{Resource: "pods"}, "pod-1"),
+			code: codes.AlreadyExists,
+			base: "resource already exists",
+		},
+		{
+			name: "invalid",
+			err: apierrors.NewInvalid(
+				schema.GroupKind{Group: "core", Kind: "Pod"},
+				"pod-1",
+				field.ErrorList{field.Invalid(field.NewPath("spec").Child("node"), "bad", "invalid node")},
+			),
+			code: codes.InvalidArgument,
+			base: "invalid kubernetes request",
+		},
+		{
+			name: "unauthorized",
+			err:  apierrors.NewUnauthorized("token missing"),
+			code: codes.Unauthenticated,
+			base: "unauthenticated",
+		},
+		{
 			name: "forbidden",
 			err:  apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "pod-1", errors.New("no access")),
 			code: codes.PermissionDenied,
 			base: "permission denied",
+		},
+		{
+			name: "conflict",
+			err:  apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, "pod-1", errors.New("update conflict")),
+			code: codes.Aborted,
+			base: "resource conflict",
 		},
 	}
 
@@ -67,7 +96,7 @@ func TestGrpcErrorFromKubeFallbackMessage(t *testing.T) {
 	if st.Code() != codes.Internal {
 		t.Fatalf("expected code %s, got %s", codes.Internal, st.Code())
 	}
-	if st.Message() != "kubernetes request failed" {
+	if st.Message() != "kubernetes request failed: boom" {
 		t.Fatalf("expected fallback message, got %q", st.Message())
 	}
 }


### PR DESCRIPTION
## Summary
- include Kubernetes status messages in gRPC error descriptions
- add grpcErrorFromKube coverage for status details
- bump Helm chart version to 0.9.0

## Testing
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet -tags e2e ./test/e2e/

Closes #43