### PR TITLE
feat: add workload and volume listing labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,13 @@ jobs:
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1
 
+      - name: Checkout api protos
+        run: |
+          git clone https://github.com/agynio/api.git /tmp/agynio-api
+          git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d
+
       - name: Generate protobuf bindings
-        run: buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/gateway/v1 --template ./buf.gen.yaml
+        run: buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o .
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
           git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d
 
       - name: Generate protobuf bindings
-        run: buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o .
+        run: |
+          cd /tmp/agynio-api
+          buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template "${GITHUB_WORKSPACE}/buf.gen.yaml" -o "${GITHUB_WORKSPACE}"
 
       - name: Run tests
         run: go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@ RUN curl -sSL \
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS build
 WORKDIR /src
 COPY --from=buf /usr/local/bin/buf /usr/local/bin/buf
+RUN apk add --no-cache git
 COPY go.mod go.sum ./
 RUN go mod download
 COPY buf.gen.yaml ./
-RUN buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/gateway/v1 --template ./buf.gen.yaml
+RUN git clone https://github.com/agynio/api.git /tmp/agynio-api && \
+    git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d
+RUN buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o .
 COPY . .
 ARG TARGETOS TARGETARCH
 ENV CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -36,7 +36,7 @@ functions:
        "value": "/opt/app/data"},
 
       {"op": "add", "path": "/spec/template/spec/containers/0/command",
-       "value": ["sh", "-c", "set -eu; elapsed=0; while [ ! -f /opt/app/data/go.mod ] || [ ! -f /opt/app/data/buf.gen.yaml ] || [ ! -f /opt/app/data/cmd/k8s-runner/main.go ]; do sleep 1; elapsed=$((elapsed + 1)); [ $elapsed -ge 120 ] && exit 1; done; echo Generating protobuf types...; rm -rf /tmp/agynio-api; git clone https://github.com/agynio/api.git /tmp/agynio-api; git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d; buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o .; echo Tidying Go modules...; go mod tidy; echo Starting k8s-runner...; go build -o /tmp/k8s-runner ./cmd/k8s-runner && exec /tmp/k8s-runner"]},
+       "value": ["sh", "-c", "set -eu; elapsed=0; while [ ! -f /opt/app/data/go.mod ] || [ ! -f /opt/app/data/buf.gen.yaml ] || [ ! -f /opt/app/data/cmd/k8s-runner/main.go ]; do sleep 1; elapsed=$((elapsed + 1)); [ $elapsed -ge 120 ] && exit 1; done; echo Generating protobuf types...; rm -rf /tmp/agynio-api; git clone https://github.com/agynio/api.git /tmp/agynio-api; git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d; cd /tmp/agynio-api; buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template /opt/app/data/buf.gen.yaml -o /opt/app/data; cd /opt/app/data; echo Tidying Go modules...; go mod tidy; echo Starting k8s-runner...; go build -o /tmp/k8s-runner ./cmd/k8s-runner && exec /tmp/k8s-runner"]},
 
       {"op": "replace", "path": "/spec/template/spec/containers/0/env",
        "value": [
@@ -187,7 +187,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=k8s-runner-e2e" \
         -n ${K8S_RUNNER_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && rm -rf /tmp/agynio-api && git clone https://github.com/agynio/api.git /tmp/agynio-api && git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d && buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o . && go mod tidy && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && rm -rf /tmp/agynio-api && git clone https://github.com/agynio/api.git /tmp/agynio-api && git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d && cd /tmp/agynio-api && buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template /opt/app/data/buf.gen.yaml -o /opt/app/data && cd /opt/app/data && go mod tidy && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       purge_deployments e2e-runner
       exit $EXIT_CODE

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -36,7 +36,7 @@ functions:
        "value": "/opt/app/data"},
 
       {"op": "add", "path": "/spec/template/spec/containers/0/command",
-       "value": ["sh", "-c", "set -eu; elapsed=0; while [ ! -f /opt/app/data/go.mod ] || [ ! -f /opt/app/data/buf.gen.yaml ] || [ ! -f /opt/app/data/cmd/k8s-runner/main.go ]; do sleep 1; elapsed=$((elapsed + 1)); [ $elapsed -ge 120 ] && exit 1; done; echo Generating protobuf types...; buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/gateway/v1 --template ./buf.gen.yaml; echo Tidying Go modules...; go mod tidy; echo Starting k8s-runner...; go build -o /tmp/k8s-runner ./cmd/k8s-runner && exec /tmp/k8s-runner"]},
+       "value": ["sh", "-c", "set -eu; elapsed=0; while [ ! -f /opt/app/data/go.mod ] || [ ! -f /opt/app/data/buf.gen.yaml ] || [ ! -f /opt/app/data/cmd/k8s-runner/main.go ]; do sleep 1; elapsed=$((elapsed + 1)); [ $elapsed -ge 120 ] && exit 1; done; echo Generating protobuf types...; rm -rf /tmp/agynio-api; git clone https://github.com/agynio/api.git /tmp/agynio-api; git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d; buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o .; echo Tidying Go modules...; go mod tidy; echo Starting k8s-runner...; go build -o /tmp/k8s-runner ./cmd/k8s-runner && exec /tmp/k8s-runner"]},
 
       {"op": "replace", "path": "/spec/template/spec/containers/0/env",
        "value": [
@@ -187,7 +187,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=k8s-runner-e2e" \
         -n ${K8S_RUNNER_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate --include-imports buf.build/agynio/api --path agynio/api/runner/v1 --path agynio/api/runners/v1 --path agynio/api/gateway/v1 --template ./buf.gen.yaml && go mod tidy && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && rm -rf /tmp/agynio-api && git clone https://github.com/agynio/api.git /tmp/agynio-api && git -C /tmp/agynio-api checkout ec008b1e2dfacec3e4d85776729fe1c3d5f2c42d && buf generate --include-imports --path proto/agynio/api/runner/v1 --path proto/agynio/api/runners/v1 --path proto/agynio/api/gateway/v1 --template ./buf.gen.yaml /tmp/agynio-api -o . && go mod tidy && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       purge_deployments e2e-runner
       exit $EXIT_CODE

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -30,7 +30,8 @@ func (s *Server) GetWorkloadLabels(ctx context.Context, req *runnerv1.GetWorkloa
 }
 
 func (s *Server) ListWorkloads(ctx context.Context, _ *runnerv1.ListWorkloadsRequest) (*runnerv1.ListWorkloadsResponse, error) {
-	list, err := s.clientset.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{})
+	selector := labels.Set(map[string]string{managedByLabelKey: managedByLabelValue}).AsSelector().String()
+	list, err := s.clientset.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, grpcErrorFromKube(s.logger, err, codes.Internal)
 	}
@@ -91,7 +92,8 @@ func (s *Server) ListWorkloadsByVolume(ctx context.Context, req *runnerv1.ListWo
 }
 
 func (s *Server) ListVolumes(ctx context.Context, _ *runnerv1.ListVolumesRequest) (*runnerv1.ListVolumesResponse, error) {
-	list, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).List(ctx, metav1.ListOptions{})
+	selector := labels.Set(map[string]string{managedByLabelKey: managedByLabelValue}).AsSelector().String()
+	list, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return nil, grpcErrorFromKube(s.logger, err, codes.Internal)
 	}

--- a/internal/server/query.go
+++ b/internal/server/query.go
@@ -29,6 +29,27 @@ func (s *Server) GetWorkloadLabels(ctx context.Context, req *runnerv1.GetWorkloa
 	return &runnerv1.GetWorkloadLabelsResponse{Labels: pod.Labels}, nil
 }
 
+func (s *Server) ListWorkloads(ctx context.Context, _ *runnerv1.ListWorkloadsRequest) (*runnerv1.ListWorkloadsResponse, error) {
+	list, err := s.clientset.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, grpcErrorFromKube(s.logger, err, codes.Internal)
+	}
+
+	workloads := make([]*runnerv1.WorkloadListItem, 0, len(list.Items))
+	for _, pod := range list.Items {
+		workloadKey, ok := pod.Labels[workloadKeyLabelKey]
+		if !ok {
+			continue
+		}
+		workloads = append(workloads, &runnerv1.WorkloadListItem{
+			InstanceId:  pod.Name,
+			WorkloadKey: workloadKey,
+		})
+	}
+
+	return &runnerv1.ListWorkloadsResponse{Workloads: workloads}, nil
+}
+
 func (s *Server) FindWorkloadsByLabels(ctx context.Context, req *runnerv1.FindWorkloadsByLabelsRequest) (*runnerv1.FindWorkloadsByLabelsResponse, error) {
 	selector := labels.Set(req.GetLabels()).AsSelector().String()
 	list, err := s.clientset.CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
@@ -67,6 +88,27 @@ func (s *Server) ListWorkloadsByVolume(ctx context.Context, req *runnerv1.ListWo
 	}
 
 	return &runnerv1.ListWorkloadsByVolumeResponse{TargetIds: ids}, nil
+}
+
+func (s *Server) ListVolumes(ctx context.Context, _ *runnerv1.ListVolumesRequest) (*runnerv1.ListVolumesResponse, error) {
+	list, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, grpcErrorFromKube(s.logger, err, codes.Internal)
+	}
+
+	volumes := make([]*runnerv1.VolumeListItem, 0, len(list.Items))
+	for _, pvc := range list.Items {
+		volumeKey, ok := pvc.Labels[volumeKeyLabelKey]
+		if !ok {
+			continue
+		}
+		volumes = append(volumes, &runnerv1.VolumeListItem{
+			InstanceId: pvc.Name,
+			VolumeKey:  volumeKey,
+		})
+	}
+
+	return &runnerv1.ListVolumesResponse{Volumes: volumes}, nil
 }
 
 func podUsesPVC(pod *corev1.Pod, pvcName string) bool {

--- a/internal/server/query_list_test.go
+++ b/internal/server/query_list_test.go
@@ -19,6 +19,7 @@ func TestListWorkloadsReturnsLabeledPods(t *testing.T) {
 				Name:      "pod-1",
 				Namespace: "default",
 				Labels: map[string]string{
+					managedByLabelKey:   managedByLabelValue,
 					workloadKeyLabelKey: "workload-1",
 				},
 			},
@@ -28,7 +29,8 @@ func TestListWorkloadsReturnsLabeledPods(t *testing.T) {
 				Name:      "pod-2",
 				Namespace: "default",
 				Labels: map[string]string{
-					"ignored": "value",
+					managedByLabelKey: managedByLabelValue,
+					"ignored":         "value",
 				},
 			},
 		},
@@ -64,6 +66,7 @@ func TestListVolumesReturnsLabeledPVCs(t *testing.T) {
 				Name:      "pvc-1",
 				Namespace: "default",
 				Labels: map[string]string{
+					managedByLabelKey: managedByLabelValue,
 					volumeKeyLabelKey: "volume-1",
 				},
 			},
@@ -73,7 +76,8 @@ func TestListVolumesReturnsLabeledPVCs(t *testing.T) {
 				Name:      "pvc-2",
 				Namespace: "default",
 				Labels: map[string]string{
-					"ignored": "value",
+					managedByLabelKey: managedByLabelValue,
+					"ignored":         "value",
 				},
 			},
 		},

--- a/internal/server/query_list_test.go
+++ b/internal/server/query_list_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+)
+
+func TestListWorkloadsReturnsLabeledPods(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					workloadKeyLabelKey: "workload-1",
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					"ignored": "value",
+				},
+			},
+		},
+	)
+
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+
+	resp, err := server.ListWorkloads(context.Background(), &runnerv1.ListWorkloadsRequest{})
+	if err != nil {
+		t.Fatalf("ListWorkloads returned error: %v", err)
+	}
+	if len(resp.Workloads) != 1 {
+		t.Fatalf("expected 1 workload, got %d", len(resp.Workloads))
+	}
+	item := resp.Workloads[0]
+	if item.InstanceId != "pod-1" {
+		t.Fatalf("expected instance id pod-1, got %q", item.InstanceId)
+	}
+	if item.WorkloadKey != "workload-1" {
+		t.Fatalf("expected workload key workload-1, got %q", item.WorkloadKey)
+	}
+}
+
+func TestListVolumesReturnsLabeledPVCs(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-1",
+				Namespace: "default",
+				Labels: map[string]string{
+					volumeKeyLabelKey: "volume-1",
+				},
+			},
+		},
+		&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pvc-2",
+				Namespace: "default",
+				Labels: map[string]string{
+					"ignored": "value",
+				},
+			},
+		},
+	)
+
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+
+	resp, err := server.ListVolumes(context.Background(), &runnerv1.ListVolumesRequest{})
+	if err != nil {
+		t.Fatalf("ListVolumes returned error: %v", err)
+	}
+	if len(resp.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(resp.Volumes))
+	}
+	item := resp.Volumes[0]
+	if item.InstanceId != "pvc-1" {
+		t.Fatalf("expected instance id pvc-1, got %q", item.InstanceId)
+	}
+	if item.VolumeKey != "volume-1" {
+		t.Fatalf("expected volume key volume-1, got %q", item.VolumeKey)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,8 @@ const (
 	managedByLabelKey      = "app.kubernetes.io/managed-by"
 	managedByLabelValue    = "k8s-runner"
 	workloadIDLabelKey     = "agyn.io/workload-id"
+	workloadKeyLabelKey    = "workload_key"
+	volumeKeyLabelKey      = "volume_key"
 	pvcAnnotationKey       = "agyn.io/pvc-names"
 	secretAnnotationKey    = "agyn.io/pull-secret-names"
 	touchedAtAnnotationKey = "agyn.io/touched-at"

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -291,15 +291,16 @@ func addLabel(target map[string]string, labelKey, value string) error {
 	if labelKey == "" {
 		return fmt.Errorf("empty label key")
 	}
+	if labelKey == managedByLabelKey || labelKey == workloadIDLabelKey {
+		return fmt.Errorf("reserved label key %q", labelKey)
+	}
 	if errs := validation.IsQualifiedName(labelKey); len(errs) > 0 {
 		return fmt.Errorf("invalid label key %q: %s", labelKey, strings.Join(errs, ", "))
 	}
 	if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
 		return fmt.Errorf("invalid label value for %q: %s", labelKey, strings.Join(errs, ", "))
 	}
-	if target != nil {
-		target[labelKey] = value
-	}
+	target[labelKey] = value
 	return nil
 }
 

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -43,7 +43,7 @@ func (s *Server) StartWorkload(ctx context.Context, req *runnerv1.StartWorkloadR
 	id := uuid.NewString()
 	podName := podNameFromID(id)
 
-	labels, err := buildLabels(id, req.AdditionalProperties)
+	labels, err := buildLabels(id, req.AdditionalProperties, req.Labels)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid_label: %v", err)
 	}
@@ -252,7 +252,7 @@ func (s *Server) TouchWorkload(ctx context.Context, req *runnerv1.TouchWorkloadR
 	return &runnerv1.TouchWorkloadResponse{}, nil
 }
 
-func buildLabels(workloadID string, additional map[string]string) (map[string]string, error) {
+func buildLabels(workloadID string, additional map[string]string, explicit map[string]string) (map[string]string, error) {
 	labels := map[string]string{
 		managedByLabelKey:  managedByLabelValue,
 		workloadIDLabelKey: workloadID,
@@ -266,16 +266,41 @@ func buildLabels(workloadID string, additional map[string]string) (map[string]st
 		if labelKey == "" {
 			return nil, fmt.Errorf("empty label key")
 		}
-		if errs := validation.IsQualifiedName(labelKey); len(errs) > 0 {
-			return nil, fmt.Errorf("invalid label key %q: %s", labelKey, strings.Join(errs, ", "))
+		if err := addLabel(labels, labelKey, value); err != nil {
+			return nil, err
 		}
-		if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
-			return nil, fmt.Errorf("invalid label value for %q: %s", labelKey, strings.Join(errs, ", "))
-		}
-		labels[labelKey] = value
+	}
+
+	if err := addLabels(labels, explicit); err != nil {
+		return nil, err
 	}
 
 	return labels, nil
+}
+
+func addLabels(target map[string]string, source map[string]string) error {
+	for key, value := range source {
+		if err := addLabel(target, key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addLabel(target map[string]string, labelKey, value string) error {
+	if labelKey == "" {
+		return fmt.Errorf("empty label key")
+	}
+	if errs := validation.IsQualifiedName(labelKey); len(errs) > 0 {
+		return fmt.Errorf("invalid label key %q: %s", labelKey, strings.Join(errs, ", "))
+	}
+	if errs := validation.IsValidLabelValue(value); len(errs) > 0 {
+		return fmt.Errorf("invalid label value for %q: %s", labelKey, strings.Join(errs, ", "))
+	}
+	if target != nil {
+		target[labelKey] = value
+	}
+	return nil
 }
 
 func buildDockerConfigJSON(registry, username, password string) ([]byte, error) {
@@ -484,6 +509,9 @@ func (s *Server) ensurePVC(ctx context.Context, volume *runnerv1.VolumeSpec, lab
 			continue
 		}
 		pvc.Labels[key] = value
+	}
+	if err := addLabels(pvc.Labels, volume.GetLabels()); err != nil {
+		return "", status.Errorf(codes.InvalidArgument, "invalid_volume_label: %v", err)
 	}
 
 	if _, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -56,6 +56,13 @@ func TestBuildLabelsRejectsInvalidExplicitLabel(t *testing.T) {
 	}
 }
 
+func TestBuildLabelsRejectsReservedLabel(t *testing.T) {
+	_, err := buildLabels("uuid-1", nil, map[string]string{managedByLabelKey: "override"})
+	if err == nil {
+		t.Fatalf("expected error for reserved label key")
+	}
+}
+
 func TestBuildDockerConfigJSON(t *testing.T) {
 	payload, err := buildDockerConfigJSON("registry.example.com", "user", "pass")
 	if err != nil {
@@ -536,6 +543,43 @@ func TestStartWorkloadAppliesLabelsToPodAndPVC(t *testing.T) {
 	}
 	if pvc.Labels[volumeKeyLabelKey] != "volume-key-1" {
 		t.Fatalf("expected volume key label %q, got %q", "volume-key-1", pvc.Labels[volumeKeyLabelKey])
+	}
+}
+
+func TestStartWorkloadRejectsReservedVolumeLabel(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+
+	ctx := context.Background()
+	req := &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Volumes: []*runnerv1.VolumeSpec{
+			{
+				Name:           "data",
+				Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+				PersistentName: "pvc-data",
+				Labels: map[string]string{
+					managedByLabelKey: "override",
+				},
+			},
+		},
+	}
+
+	_, err := server.StartWorkload(ctx, req)
+	if err == nil {
+		t.Fatalf("expected error for reserved volume label")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument error, got %v", err)
+	}
+	if !strings.Contains(st.Message(), "invalid_volume_label") {
+		t.Fatalf("expected invalid volume label error, got %q", st.Message())
 	}
 }
 

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -24,15 +24,16 @@ func TestBuildLabelsFiltersAndValidates(t *testing.T) {
 	labels, err := buildLabels("uuid-1", map[string]string{
 		"label.team": "core",
 		"ignored":    "value",
-	})
+	}, map[string]string{workloadKeyLabelKey: "workload-1"})
 	if err != nil {
 		t.Fatalf("buildLabels returned error: %v", err)
 	}
 
 	expected := map[string]string{
-		managedByLabelKey:  managedByLabelValue,
-		workloadIDLabelKey: "uuid-1",
-		"team":             "core",
+		managedByLabelKey:   managedByLabelValue,
+		workloadIDLabelKey:  "uuid-1",
+		workloadKeyLabelKey: "workload-1",
+		"team":              "core",
 	}
 	if !reflect.DeepEqual(labels, expected) {
 		t.Fatalf("labels mismatch: got %#v want %#v", labels, expected)
@@ -42,9 +43,16 @@ func TestBuildLabelsFiltersAndValidates(t *testing.T) {
 func TestBuildLabelsRejectsInvalidKey(t *testing.T) {
 	_, err := buildLabels("uuid-1", map[string]string{
 		"label.bad key": "value",
-	})
+	}, nil)
 	if err == nil {
 		t.Fatalf("expected error for invalid label key")
+	}
+}
+
+func TestBuildLabelsRejectsInvalidExplicitLabel(t *testing.T) {
+	_, err := buildLabels("uuid-1", nil, map[string]string{"bad key": "value"})
+	if err == nil {
+		t.Fatalf("expected error for invalid explicit label key")
 	}
 }
 
@@ -462,6 +470,72 @@ func TestStartWorkloadCreatesImagePullSecrets(t *testing.T) {
 		if !reflect.DeepEqual(secret.Data[corev1.DockerConfigJsonKey], expectedConfig) {
 			t.Fatalf("expected docker config data to match")
 		}
+	}
+}
+
+func TestStartWorkloadAppliesLabelsToPodAndPVC(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+
+	ctx := context.Background()
+	req := &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Labels: map[string]string{
+			workloadKeyLabelKey: "workload-key-1",
+			"team":              "core",
+		},
+		Volumes: []*runnerv1.VolumeSpec{
+			{
+				Name:           "data",
+				Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+				PersistentName: "pvc-data",
+				Labels: map[string]string{
+					volumeKeyLabelKey: "volume-key-1",
+				},
+			},
+		},
+	}
+
+	resp, err := server.StartWorkload(ctx, req)
+	if err != nil {
+		t.Fatalf("StartWorkload returned error: %v", err)
+	}
+	if resp == nil || resp.Id == "" {
+		t.Fatalf("expected response with id")
+	}
+
+	podName := podNameFromID(resp.Id)
+	pod, err := clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pod created: %v", err)
+	}
+	if pod.Labels[managedByLabelKey] != managedByLabelValue {
+		t.Fatalf("expected managed-by label %q, got %q", managedByLabelValue, pod.Labels[managedByLabelKey])
+	}
+	if pod.Labels[workloadIDLabelKey] != resp.Id {
+		t.Fatalf("expected workload id label %q, got %q", resp.Id, pod.Labels[workloadIDLabelKey])
+	}
+	if pod.Labels[workloadKeyLabelKey] != "workload-key-1" {
+		t.Fatalf("expected workload key label %q, got %q", "workload-key-1", pod.Labels[workloadKeyLabelKey])
+	}
+	if pod.Labels["team"] != "core" {
+		t.Fatalf("expected team label %q, got %q", "core", pod.Labels["team"])
+	}
+
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims("default").Get(ctx, "pvc-data", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pvc created: %v", err)
+	}
+	if pvc.Labels[managedByLabelKey] != managedByLabelValue {
+		t.Fatalf("expected pvc managed-by label %q, got %q", managedByLabelValue, pvc.Labels[managedByLabelKey])
+	}
+	if pvc.Labels[volumeKeyLabelKey] != "volume-key-1" {
+		t.Fatalf("expected volume key label %q, got %q", "volume-key-1", pvc.Labels[volumeKeyLabelKey])
 	}
 }
 


### PR DESCRIPTION
## Summary
- apply StartWorkload labels to pods and volume labels to PVCs
- implement ListWorkloads/ListVolumes responses from pod/PVC labels
- add coverage for label application and list queries

## Testing
- CGO_ENABLED=0 go vet ./...
- CGO_ENABLED=0 go test ./...
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet -tags e2e ./test/e2e/
- CGO_ENABLED=0 go test -json ./...

Related: agynio/runners#20