### PR TITLE
fix(server): use docker rootless tag

### DIFF
--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -17,7 +17,7 @@ const (
 	dockerSidecarName             = "docker-daemon"
 	dockerDataVolumeName          = "docker-data"
 	dockerRunVolumeName           = "docker-run"
-	dockerRootlessImage           = "docker:27-rootless"
+	dockerRootlessImage           = "docker:27-dind-rootless"
 	dockerPrivilegedImage         = "docker:27-dind"
 	dockerTLSCertDirEnvName       = "DOCKER_TLS_CERTDIR"
 	dockerTLSCertDirDisabledValue = ""


### PR DESCRIPTION
## Summary
- update rootless Docker sidecar image tag to official dind rootless tag

## Testing
- go test ./...
- go vet ./...
- go build ./...

## Related
- Fixes #51