### PR TITLE
fix(server): leave hostUsers unset

### DIFF
--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -78,10 +78,6 @@ func (plan capabilityPlan) apply(containers *[]corev1.Container, volumes *[]core
 	*containers = append(*containers, dockerSidecarContainer(plan.dockerImplementation))
 	*sidecarNames = append(*sidecarNames, dockerSidecarName)
 	*volumes = append(*volumes, dockerVolumes(plan.dockerImplementation)...)
-
-	if plan.dockerImplementation == config.DockerImplementationRootless {
-		return boolPtr(false)
-	}
 	return nil
 }
 
@@ -229,8 +225,4 @@ func upsertEnvVar(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
 		result = append(result, env)
 	}
 	return append(result, corev1.EnvVar{Name: name, Value: value})
-}
-
-func boolPtr(value bool) *bool {
-	return &value
 }

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -452,8 +452,8 @@ func TestStartWorkloadInjectsDockerRootless(t *testing.T) {
 		t.Fatalf("expected pod created: %v", err)
 	}
 
-	if pod.Spec.HostUsers == nil || *pod.Spec.HostUsers {
-		t.Fatalf("expected hostUsers false for rootless docker")
+	if pod.Spec.HostUsers != nil {
+		t.Fatalf("expected hostUsers to remain unset for rootless docker")
 	}
 
 	main := findContainer(pod.Spec.Containers, "main")


### PR DESCRIPTION
## Summary
- leave pod.spec.hostUsers unset for rootless docker capability
- update rootless docker workload test expectations

## Testing
- go test ./...
- go vet ./...

Closes #53