### PR TITLE
fix(server): mount rootless data parent

### DIFF
--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -24,7 +24,7 @@ const (
 	dockerTLSCertDirDisabledValue = ""
 	dockerHostEnvName             = "DOCKER_HOST"
 	dockerHostEnvValue            = "tcp://localhost:2375"
-	dockerRootlessDataMountPath   = "/home/rootless/.local/share/docker"
+	dockerRootlessDataMountPath   = "/home/rootless/.local/share"
 	dockerRootlessRunMountPath    = "/run/user/1000"
 	dockerTunDevicePath           = "/dev/net/tun"
 	dockerPrivilegedDataMountPath = "/var/lib/docker"

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -470,7 +470,7 @@ func TestStartWorkloadInjectsDockerRootless(t *testing.T) {
 		t.Fatalf("expected rootless docker image %q, got %q", dockerRootlessImage, sidecar.Image)
 	}
 	assertEnvValue(t, sidecar.Env, dockerTLSCertDirEnvName, dockerTLSCertDirDisabledValue)
-	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, dockerRootlessDataMountPath)
+	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, "/home/rootless/.local/share")
 	assertVolumeMount(t, sidecar.VolumeMounts, dockerRunVolumeName, dockerRootlessRunMountPath)
 	assertVolumeMount(t, sidecar.VolumeMounts, dockerTunVolumeName, dockerTunDevicePath)
 	assertEmptyDirVolume(t, pod.Spec.Volumes, dockerDataVolumeName)


### PR DESCRIPTION
## Summary
- mount rootless docker data volume at /home/rootless/.local/share
- update rootless docker injection test expectation

## Testing
- go test ./...
- go vet ./...

Closes #53