### PR TITLE
fix(server): unconfine rootless seccomp

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ devspace run test:e2e
 ```
 
 See [E2E Testing](https://github.com/agynio/architecture/blob/main/architecture/operations/e2e-testing.md).
+
+## Docker capability notes
+
+The `docker` capability injects a Docker sidecar. For the **rootless**
+implementation, the sidecar runs nested `runc` and requires additional
+permissions and mounts to allow `docker run` to work:
+
+- `allowPrivilegeEscalation: true` for rootlesskit/newuidmap.
+- `seccompProfile: Unconfined` and `appArmorProfile: Unconfined` because
+  default RuntimeDefault/AppArmor profiles block mount-related syscalls
+  (for example mounting `/proc`) required by nested `runc`.
+- HostPath mount for `/dev/net/tun` (type `CharDevice`).
+- `docker-data` emptyDir mounted at `/home/rootless/.local/share` so dockerd
+  can create its own `docker/` data root with correct ownership.
+
+These settings can require Pod Security Admission exceptions for docker-capable
+workloads (baseline/restricted clusters may reject them).

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -182,6 +182,9 @@ func dockerSidecarContainer(implementation config.DockerImplementation) corev1.C
 				{Name: dockerRunVolumeName, MountPath: dockerRootlessRunMountPath},
 				{Name: dockerTunVolumeName, MountPath: dockerTunDevicePath},
 			},
+			// Rootless dockerd launches a nested runc; default RuntimeDefault
+			// seccomp/AppArmor profiles block mount-related syscalls (notably
+			// mounting proc), so unconfined is required for docker run to work.
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 				SeccompProfile:           seccompProfile,

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -170,6 +170,9 @@ func dockerSidecarContainer(implementation config.DockerImplementation) corev1.C
 	env := []corev1.EnvVar{{Name: dockerTLSCertDirEnvName, Value: dockerTLSCertDirDisabledValue}}
 	switch implementation {
 	case config.DockerImplementationRootless:
+		allowPrivilegeEscalation := true
+		seccompProfile := &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}
+		appArmorProfile := &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeUnconfined}
 		return corev1.Container{
 			Name:  dockerSidecarName,
 			Image: dockerRootlessImage,
@@ -178,6 +181,11 @@ func dockerSidecarContainer(implementation config.DockerImplementation) corev1.C
 				{Name: dockerDataVolumeName, MountPath: dockerRootlessDataMountPath},
 				{Name: dockerRunVolumeName, MountPath: dockerRootlessRunMountPath},
 				{Name: dockerTunVolumeName, MountPath: dockerTunDevicePath},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				SeccompProfile:           seccompProfile,
+				AppArmorProfile:          appArmorProfile,
 			},
 		}
 	case config.DockerImplementationPrivileged:

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -469,8 +469,20 @@ func TestStartWorkloadInjectsDockerRootless(t *testing.T) {
 	if sidecar.Image != dockerRootlessImage {
 		t.Fatalf("expected rootless docker image %q, got %q", dockerRootlessImage, sidecar.Image)
 	}
+	if sidecar.SecurityContext == nil {
+		t.Fatal("expected docker sidecar security context")
+	}
+	if sidecar.SecurityContext.AllowPrivilegeEscalation == nil || !*sidecar.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatalf("expected allowPrivilegeEscalation true for rootless docker")
+	}
+	if sidecar.SecurityContext.SeccompProfile == nil || sidecar.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeUnconfined {
+		t.Fatalf("expected seccomp profile unconfined for rootless docker")
+	}
+	if sidecar.SecurityContext.AppArmorProfile == nil || sidecar.SecurityContext.AppArmorProfile.Type != corev1.AppArmorProfileTypeUnconfined {
+		t.Fatalf("expected appArmor profile unconfined for rootless docker")
+	}
 	assertEnvValue(t, sidecar.Env, dockerTLSCertDirEnvName, dockerTLSCertDirDisabledValue)
-	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, "/home/rootless/.local/share")
+	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, dockerRootlessDataMountPath)
 	assertVolumeMount(t, sidecar.VolumeMounts, dockerRunVolumeName, dockerRootlessRunMountPath)
 	assertVolumeMount(t, sidecar.VolumeMounts, dockerTunVolumeName, dockerTunDevicePath)
 	assertEmptyDirVolume(t, pod.Spec.Volumes, dockerDataVolumeName)


### PR DESCRIPTION
## Summary
- relax rootless docker sidecar security context (allowPrivilegeEscalation, seccomp unconfined, AppArmor unconfined)
- update rootless injection tests to assert security context fields

## Testing
- go test ./...
- go vet ./...

Closes #53