### PR TITLE
fix(server): add legacy seccomp annotations

### DIFF
--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -28,6 +28,10 @@ const (
 	dockerRootlessRunMountPath    = "/run/user/1000"
 	dockerTunDevicePath           = "/dev/net/tun"
 	dockerPrivilegedDataMountPath = "/var/lib/docker"
+	dockerAppArmorLegacyAnnotationKey = "container.apparmor.security.beta.kubernetes.io/" + dockerSidecarName
+	dockerSeccompPodAnnotationKey     = "seccomp.security.alpha.kubernetes.io/pod"
+	dockerSeccompContainerAnnotationKey = "container.seccomp.security.alpha.kubernetes.io/" + dockerSidecarName
+	dockerSecurityProfileUnconfined     = "unconfined"
 )
 
 type capabilityPlan struct {

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	runnerv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runner/v1"
+	"github.com/agynio/k8s-runner/internal/config"
 )
 
 type dockerConfig struct {
@@ -80,6 +81,11 @@ func (s *Server) StartWorkload(ctx context.Context, req *runnerv1.StartWorkloadR
 	}
 	if len(secretNames) > 0 {
 		annotations[secretAnnotationKey] = strings.Join(secretNames, ",")
+	}
+	if capabilityPlan.dockerImplementation == config.DockerImplementationRootless {
+		annotations[dockerAppArmorLegacyAnnotationKey] = dockerSecurityProfileUnconfined
+		annotations[dockerSeccompPodAnnotationKey] = dockerSecurityProfileUnconfined
+		annotations[dockerSeccompContainerAnnotationKey] = dockerSecurityProfileUnconfined
 	}
 
 	pod := &corev1.Pod{

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -455,6 +455,9 @@ func TestStartWorkloadInjectsDockerRootless(t *testing.T) {
 	if pod.Spec.HostUsers != nil {
 		t.Fatalf("expected hostUsers to remain unset for rootless docker")
 	}
+	assertAnnotation(t, pod.Annotations, dockerAppArmorLegacyAnnotationKey, dockerSecurityProfileUnconfined)
+	assertAnnotation(t, pod.Annotations, dockerSeccompPodAnnotationKey, dockerSecurityProfileUnconfined)
+	assertAnnotation(t, pod.Annotations, dockerSeccompContainerAnnotationKey, dockerSecurityProfileUnconfined)
 
 	main := findContainer(pod.Spec.Containers, "main")
 	if main == nil {
@@ -1133,6 +1136,17 @@ func assertEnvValue(t *testing.T, envs []corev1.EnvVar, name, expected string) {
 		return
 	}
 	t.Fatalf("expected env %s to be set", name)
+}
+
+func assertAnnotation(t *testing.T, annotations map[string]string, key, expected string) {
+	t.Helper()
+	value, ok := annotations[key]
+	if !ok {
+		t.Fatalf("expected annotation %s", key)
+	}
+	if value != expected {
+		t.Fatalf("expected annotation %s=%q, got %q", key, expected, value)
+	}
 }
 
 func assertVolumeMount(t *testing.T, mounts []corev1.VolumeMount, name, mountPath string) {


### PR DESCRIPTION
## Summary
- add legacy AppArmor/seccomp pod annotations for rootless docker sidecar
- ensure rootless workload tests assert legacy annotations

## Testing
- go test ./...
- go vet ./...

Closes #53