### PR TITLE
fix(server): unmask proc for rootless

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ permissions and mounts to allow `docker run` to work:
 - `seccompProfile: Unconfined` and `appArmorProfile: Unconfined` because
   default RuntimeDefault/AppArmor profiles block mount-related syscalls
   (for example mounting `/proc`) required by nested `runc`.
+- `procMount: Unmasked` to avoid `/proc` mount masking interfering with
+  nested `runc` container setup.
 - HostPath mount for `/dev/net/tun` (type `CharDevice`).
 - `docker-data` emptyDir mounted at `/home/rootless/.local/share` so dockerd
   can create its own `docker/` data root with correct ownership.

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -177,6 +177,7 @@ func dockerSidecarContainer(implementation config.DockerImplementation) corev1.C
 		allowPrivilegeEscalation := true
 		seccompProfile := &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeUnconfined}
 		appArmorProfile := &corev1.AppArmorProfile{Type: corev1.AppArmorProfileTypeUnconfined}
+		procMount := corev1.UnmaskedProcMount
 		return corev1.Container{
 			Name:  dockerSidecarName,
 			Image: dockerRootlessImage,
@@ -193,6 +194,7 @@ func dockerSidecarContainer(implementation config.DockerImplementation) corev1.C
 				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 				SeccompProfile:           seccompProfile,
 				AppArmorProfile:          appArmorProfile,
+				ProcMount:                &procMount,
 			},
 		}
 	case config.DockerImplementationPrivileged:

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -485,6 +485,9 @@ func TestStartWorkloadInjectsDockerRootless(t *testing.T) {
 	if sidecar.SecurityContext.AppArmorProfile == nil || sidecar.SecurityContext.AppArmorProfile.Type != corev1.AppArmorProfileTypeUnconfined {
 		t.Fatalf("expected appArmor profile unconfined for rootless docker")
 	}
+	if sidecar.SecurityContext.ProcMount == nil || *sidecar.SecurityContext.ProcMount != corev1.UnmaskedProcMount {
+		t.Fatalf("expected procMount unmasked for rootless docker")
+	}
 	assertEnvValue(t, sidecar.Env, dockerTLSCertDirEnvName, dockerTLSCertDirDisabledValue)
 	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, dockerRootlessDataMountPath)
 	assertVolumeMount(t, sidecar.VolumeMounts, dockerRunVolumeName, dockerRootlessRunMountPath)


### PR DESCRIPTION
## Summary
- set ProcMount=Unmasked for rootless docker sidecar security context
- update rootless docker test assertions
- document procMount requirement for rootless docker

## Testing
- go test ./...
- go vet ./...

Closes #53