### PR TITLE
feat: add kata runtimeClass for docker capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,11 @@ permissions and mounts to allow `docker run` to work:
 
 These settings can require Pod Security Admission exceptions for docker-capable
 workloads (baseline/restricted clusters may reject them).
+
+### Kata (microVM) docker runtimes
+
+`CAPABILITY_IMPLEMENTATIONS` also supports `docker: kata-qemu` (and optionally
+`docker: kata-fc`). When enabled, k8s-runner keeps the privileged DinD sidecar
+behavior but sets `pod.spec.runtimeClassName` to match the selected Kata
+implementation. The cluster must provide the matching RuntimeClass and schedule
+onto KVM-capable nodes. This cannot be validated on local k3d/mac setups.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,8 @@ type DockerImplementation string
 const (
 	DockerImplementationRootless   DockerImplementation = "rootless"
 	DockerImplementationPrivileged DockerImplementation = "privileged"
+	DockerImplementationKataQemu   DockerImplementation = "kata-qemu"
+	DockerImplementationKataFc     DockerImplementation = "kata-fc"
 )
 
 type CapabilityImplementations struct {
@@ -185,6 +187,10 @@ func parseCapabilityImplementations(raw string) (CapabilityImplementations, erro
 				implementations.Docker = DockerImplementationRootless
 			case DockerImplementationPrivileged:
 				implementations.Docker = DockerImplementationPrivileged
+			case DockerImplementationKataQemu:
+				implementations.Docker = DockerImplementationKataQemu
+			case DockerImplementationKataFc:
+				implementations.Docker = DockerImplementationKataFc
 			default:
 				return CapabilityImplementations{}, fmt.Errorf("invalid docker capability implementation %q", value)
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -98,6 +98,16 @@ func TestParseCapabilityImplementations(t *testing.T) {
 			expected: CapabilityImplementations{Docker: DockerImplementationPrivileged},
 		},
 		{
+			name:     "kata qemu",
+			raw:      `{"docker":"kata-qemu"}`,
+			expected: CapabilityImplementations{Docker: DockerImplementationKataQemu},
+		},
+		{
+			name:     "kata fc",
+			raw:      `{"docker":"kata-fc"}`,
+			expected: CapabilityImplementations{Docker: DockerImplementationKataFc},
+		},
+		{
 			name:        "invalid docker",
 			raw:         `{"docker":"unsupported"}`,
 			errContains: "invalid docker capability implementation",

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -79,6 +79,7 @@ write_subid "/subid/subgid" "$gid_length"
 
 type capabilityPlan struct {
 	dockerImplementation config.DockerImplementation
+	runtimeClassName     *string
 }
 
 func resolveCapabilityPlan(req *runnerv1.StartWorkloadRequest, implementations config.CapabilityImplementations) (capabilityPlan, error) {
@@ -101,13 +102,14 @@ func resolveCapabilityPlan(req *runnerv1.StartWorkloadRequest, implementations c
 			if implementation == "" {
 				return plan, status.Error(codes.InvalidArgument, "docker_capability_not_configured")
 			}
-			if implementation != config.DockerImplementationRootless && implementation != config.DockerImplementationPrivileged {
+			if !isSupportedDockerImplementation(implementation) {
 				return plan, status.Errorf(codes.InvalidArgument, "unknown_docker_implementation: %s", implementation)
 			}
 			if err := validateDockerInjection(containerNames, volumeNames, implementation); err != nil {
 				return plan, err
 			}
 			plan.dockerImplementation = implementation
+			plan.runtimeClassName = dockerRuntimeClassName(implementation)
 		default:
 			return plan, status.Errorf(codes.InvalidArgument, "unknown_capability: %s", capability)
 		}
@@ -255,7 +257,7 @@ func dockerSidecarContainer(implementation config.DockerImplementation) corev1.C
 				ProcMount:                &procMount,
 			},
 		}
-	case config.DockerImplementationPrivileged:
+	case config.DockerImplementationPrivileged, config.DockerImplementationKataQemu, config.DockerImplementationKataFc:
 		privileged := true
 		return corev1.Container{
 			Name:  dockerSidecarName,
@@ -318,8 +320,32 @@ func dockerVolumes(implementation config.DockerImplementation) []corev1.Volume {
 			},
 		}
 		return []corev1.Volume{dataVolume, runVolume, tunVolume, subidVolume}
-	case config.DockerImplementationPrivileged:
+	case config.DockerImplementationPrivileged, config.DockerImplementationKataQemu, config.DockerImplementationKataFc:
 		return []corev1.Volume{dataVolume}
+	default:
+		panic(fmt.Sprintf("unsupported docker implementation: %s", implementation))
+	}
+}
+
+func isSupportedDockerImplementation(implementation config.DockerImplementation) bool {
+	switch implementation {
+	case config.DockerImplementationRootless,
+		config.DockerImplementationPrivileged,
+		config.DockerImplementationKataQemu,
+		config.DockerImplementationKataFc:
+		return true
+	default:
+		return false
+	}
+}
+
+func dockerRuntimeClassName(implementation config.DockerImplementation) *string {
+	switch implementation {
+	case config.DockerImplementationRootless, config.DockerImplementationPrivileged:
+		return nil
+	case config.DockerImplementationKataQemu, config.DockerImplementationKataFc:
+		name := string(implementation)
+		return &name
 	default:
 		panic(fmt.Sprintf("unsupported docker implementation: %s", implementation))
 	}

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -106,6 +106,9 @@ func (s *Server) StartWorkload(ctx context.Context, req *runnerv1.StartWorkloadR
 	if hostUsers != nil {
 		pod.Spec.HostUsers = hostUsers
 	}
+	if capabilityPlan.runtimeClassName != nil {
+		pod.Spec.RuntimeClassName = capabilityPlan.runtimeClassName
+	}
 
 	if len(imagePullSecrets) > 0 {
 		pod.Spec.ImagePullSecrets = imagePullSecrets

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -456,6 +456,7 @@ func TestStartWorkloadInjectsDockerRootless(t *testing.T) {
 	if pod.Spec.HostUsers == nil || *pod.Spec.HostUsers {
 		t.Fatalf("expected hostUsers false for rootless docker")
 	}
+	assertRuntimeClassNameUnset(t, pod.Spec.RuntimeClassName)
 	if len(pod.Spec.InitContainers) != 1 {
 		t.Fatalf("expected 1 init container, got %d", len(pod.Spec.InitContainers))
 	}
@@ -544,36 +545,80 @@ func TestStartWorkloadInjectsDockerPrivileged(t *testing.T) {
 	if pod.Spec.HostUsers != nil {
 		t.Fatalf("expected hostUsers to remain unset for privileged docker")
 	}
+	assertRuntimeClassNameUnset(t, pod.Spec.RuntimeClassName)
+	assertPrivilegedDockerInjection(t, pod, resp)
+}
 
-	main := findContainer(pod.Spec.Containers, "main")
-	if main == nil {
-		t.Fatal("expected main container")
-	}
-	assertEnvValue(t, main.Env, dockerHostEnvName, dockerHostEnvValue)
+func TestStartWorkloadInjectsDockerKataQemu(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+		CapabilityImplementations: config.CapabilityImplementations{
+			Docker: config.DockerImplementationKataQemu,
+		},
+	})
 
-	sidecar := findContainer(pod.Spec.Containers, dockerSidecarName)
-	if sidecar == nil {
-		t.Fatal("expected docker sidecar container")
+	ctx := context.Background()
+	req := &runnerv1.StartWorkloadRequest{
+		Main:         &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Capabilities: []string{dockerCapability},
 	}
-	if sidecar.Image != dockerPrivilegedImage {
-		t.Fatalf("expected privileged docker image %q, got %q", dockerPrivilegedImage, sidecar.Image)
+
+	resp, err := server.StartWorkload(ctx, req)
+	if err != nil {
+		t.Fatalf("StartWorkload returned error: %v", err)
 	}
-	if sidecar.SecurityContext == nil || sidecar.SecurityContext.Privileged == nil || !*sidecar.SecurityContext.Privileged {
-		t.Fatalf("expected docker sidecar to be privileged")
+
+	podName := podNameFromID(resp.Id)
+	pod, err := clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pod created: %v", err)
 	}
-	if sidecar.SecurityContext.AllowPrivilegeEscalation == nil || !*sidecar.SecurityContext.AllowPrivilegeEscalation {
-		t.Fatalf("expected docker sidecar to allow privilege escalation")
+
+	if pod.Spec.HostUsers != nil {
+		t.Fatalf("expected hostUsers to remain unset for kata docker")
 	}
-	assertEnvValue(t, sidecar.Env, dockerTLSCertDirEnvName, dockerTLSCertDirDisabledValue)
-	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, dockerPrivilegedDataMountPath)
-	assertEmptyDirVolume(t, pod.Spec.Volumes, dockerDataVolumeName)
-	if findVolume(pod.Spec.Volumes, dockerRunVolumeName) != nil {
-		t.Fatalf("expected no docker run volume for privileged docker")
+	assertRuntimeClassName(t, pod.Spec.RuntimeClassName, string(config.DockerImplementationKataQemu))
+	assertPrivilegedDockerInjection(t, pod, resp)
+}
+
+func TestStartWorkloadInjectsDockerKataFc(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+		CapabilityImplementations: config.CapabilityImplementations{
+			Docker: config.DockerImplementationKataFc,
+		},
+	})
+
+	ctx := context.Background()
+	req := &runnerv1.StartWorkloadRequest{
+		Main:         &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Capabilities: []string{dockerCapability},
 	}
-	if findVolume(pod.Spec.Volumes, dockerTunVolumeName) != nil {
-		t.Fatalf("expected no docker tun volume for privileged docker")
+
+	resp, err := server.StartWorkload(ctx, req)
+	if err != nil {
+		t.Fatalf("StartWorkload returned error: %v", err)
 	}
-	assertSidecarInstance(t, resp.GetContainers().GetSidecars(), dockerSidecarName)
+
+	podName := podNameFromID(resp.Id)
+	pod, err := clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pod created: %v", err)
+	}
+
+	if pod.Spec.HostUsers != nil {
+		t.Fatalf("expected hostUsers to remain unset for kata docker")
+	}
+	assertRuntimeClassName(t, pod.Spec.RuntimeClassName, string(config.DockerImplementationKataFc))
+	assertPrivilegedDockerInjection(t, pod, resp)
 }
 
 func TestStartWorkloadRejectsUnknownCapability(t *testing.T) {
@@ -1356,6 +1401,56 @@ func assertEnvValue(t *testing.T, envs []corev1.EnvVar, name, expected string) {
 		return
 	}
 	t.Fatalf("expected env %s to be set", name)
+}
+
+func assertPrivilegedDockerInjection(t *testing.T, pod *corev1.Pod, resp *runnerv1.StartWorkloadResponse) {
+	t.Helper()
+	main := findContainer(pod.Spec.Containers, "main")
+	if main == nil {
+		t.Fatal("expected main container")
+	}
+	assertEnvValue(t, main.Env, dockerHostEnvName, dockerHostEnvValue)
+
+	sidecar := findContainer(pod.Spec.Containers, dockerSidecarName)
+	if sidecar == nil {
+		t.Fatal("expected docker sidecar container")
+	}
+	if sidecar.Image != dockerPrivilegedImage {
+		t.Fatalf("expected privileged docker image %q, got %q", dockerPrivilegedImage, sidecar.Image)
+	}
+	if sidecar.SecurityContext == nil || sidecar.SecurityContext.Privileged == nil || !*sidecar.SecurityContext.Privileged {
+		t.Fatalf("expected docker sidecar to be privileged")
+	}
+	if sidecar.SecurityContext.AllowPrivilegeEscalation == nil || !*sidecar.SecurityContext.AllowPrivilegeEscalation {
+		t.Fatalf("expected docker sidecar to allow privilege escalation")
+	}
+	assertEnvValue(t, sidecar.Env, dockerTLSCertDirEnvName, dockerTLSCertDirDisabledValue)
+	assertVolumeMount(t, sidecar.VolumeMounts, dockerDataVolumeName, dockerPrivilegedDataMountPath)
+	assertEmptyDirVolume(t, pod.Spec.Volumes, dockerDataVolumeName)
+	if findVolume(pod.Spec.Volumes, dockerRunVolumeName) != nil {
+		t.Fatalf("expected no docker run volume for privileged docker")
+	}
+	if findVolume(pod.Spec.Volumes, dockerTunVolumeName) != nil {
+		t.Fatalf("expected no docker tun volume for privileged docker")
+	}
+	assertSidecarInstance(t, resp.GetContainers().GetSidecars(), dockerSidecarName)
+}
+
+func assertRuntimeClassName(t *testing.T, runtimeClassName *string, expected string) {
+	t.Helper()
+	if runtimeClassName == nil {
+		t.Fatalf("expected runtimeClassName %q", expected)
+	}
+	if *runtimeClassName != expected {
+		t.Fatalf("expected runtimeClassName %q, got %q", expected, *runtimeClassName)
+	}
+}
+
+func assertRuntimeClassNameUnset(t *testing.T, runtimeClassName *string) {
+	t.Helper()
+	if runtimeClassName != nil {
+		t.Fatalf("expected runtimeClassName to be unset")
+	}
 }
 
 func assertAnnotation(t *testing.T, annotations map[string]string, key, expected string) {


### PR DESCRIPTION
## Summary
- add kata-qemu/kata-fc docker implementations and runtimeClass mapping
- keep privileged DinD behavior for kata docker workloads
- extend docker capability tests and update README prerequisites

## Testing
- buf generate --include-imports
- go test ./...
- go vet ./...

Closes #64