### PR TITLE
ci: align e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -13,22 +16,24 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        uses: agynio/bootstrap/.github/actions/provision@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
 
       - name: Deploy k8s-runner from source
-        run: devspace run deploy -n platform
+        run: devspace run deploy
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: k8s_runner
+
+      - name: Restore ArgoCD sync
+        if: always()
+        run: devspace run restore-argocd

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,7 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: k8s_runner
+          include_smoke: false
 
       - name: Restore ArgoCD sync
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,6 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: k8s_runner
-          include_smoke: false
 
       - name: Restore ArgoCD sync
         if: always()

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -99,9 +99,9 @@ functions:
 
 commands:
   deploy: |-
-    devspace run-pipeline deploy -n ${DEVSPACE_NAMESPACE} $@
+    devspace run-pipeline deploy $@
   restore-argocd: |-
-    devspace run-pipeline restore-argocd -n ${DEVSPACE_NAMESPACE} $@
+    devspace run-pipeline restore-argocd $@
 
 pipelines:
   dev:


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy k8s-runner from source with DevSpace, then run `agynio/e2e/.github/actions/run-tests@main`.
- Replaces the pinned bootstrap action commit with `@main`.
- Removes namespace override from the DevSpace deploy command.
- Adds read-only workflow permissions to CI/E2E and restores ArgoCD sync after E2E.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #67

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `buf generate --include-imports` — passed.
- `go test ./...` — 80 passed, 0 failed, 0 skipped.
- `go build ./...` — passed.