### PR TITLE
Egress v1: mount inline files and add NetworkPolicy template

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,17 @@ workloads (baseline/restricted clusters may reject them).
 behavior but sets `pod.spec.runtimeClassName` to match the selected Kata
 implementation. The cluster must provide the matching RuntimeClass and schedule
 onto KVM-capable nodes. This cannot be validated on local k3d/mac setups.
+
+## Workload egress NetworkPolicy
+
+The Helm chart can install the static egress NetworkPolicy used by egress v1.
+Enable `workloadEgressNetworkPolicy.enabled` and set `workloadNamespace` to the
+namespace where runner-created workload pods run. The policy selects workload
+pods with `agyn.dev/managed-by=agents-orchestrator`, allows OpenZiti synthetic
+addresses (`100.64.0.0/10`), cluster DNS, and public internet, and excludes the
+CIDRs listed in `workloadEgressNetworkPolicy.blockedCIDRs` from public internet
+egress. Operators should include the cluster pod CIDR, cluster service CIDR, and
+any additional internal CIDRs in that list.
+
+The runner runtime does not create or update NetworkPolicy resources, and its
+ServiceAccount does not need `networkpolicies` RBAC.

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.workloadEgressNetworkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.workloadEgressNetworkPolicy.name | quote }}
+  namespace: {{ default .Release.Namespace .Values.workloadNamespace | quote }}
+  labels:
+    {{- include "service-base.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- toYaml .Values.workloadEgressNetworkPolicy.podSelectorLabels | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.workloadEgressNetworkPolicy.openZitiCIDR | quote }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.workloadEgressNetworkPolicy.dns.namespaceSelector | nindent 14 }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.workloadEgressNetworkPolicy.dns.podSelector | nindent 14 }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.workloadEgressNetworkPolicy.publicInternetCIDR | quote }}
+            {{- with .Values.workloadEgressNetworkPolicy.blockedCIDRs }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+{{- end }}

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -186,3 +186,19 @@ metrics:
         path: /metrics
         interval: ""
         scrapeTimeout: ""
+
+workloadNamespace: agyn-workloads
+
+workloadEgressNetworkPolicy:
+  enabled: false
+  name: agent-workload-egress
+  podSelectorLabels:
+    agyn.dev/managed-by: agents-orchestrator
+  openZitiCIDR: 100.64.0.0/10
+  dns:
+    namespaceSelector:
+      kubernetes.io/metadata.name: kube-system
+    podSelector:
+      k8s-app: kube-dns
+  publicInternetCIDR: 0.0.0.0/0
+  blockedCIDRs: []

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,15 +13,17 @@ import (
 )
 
 const (
-	managedByLabelKey      = "app.kubernetes.io/managed-by"
-	managedByLabelValue    = "k8s-runner"
-	workloadIDLabelKey     = "agyn.io/workload-id"
-	workloadKeyLabelKey    = "workload_key"
-	volumeKeyLabelKey      = "volume_key"
-	pvcAnnotationKey       = "agyn.io/pvc-names"
-	secretAnnotationKey    = "agyn.io/pull-secret-names"
-	inlineFilesVolumeName  = "inline-files"
-	touchedAtAnnotationKey = "agyn.io/touched-at"
+	managedByLabelKey           = "app.kubernetes.io/managed-by"
+	managedByLabelValue         = "k8s-runner"
+	workloadManagedByLabelKey   = "agyn.dev/managed-by"
+	workloadManagedByLabelValue = "agents-orchestrator"
+	workloadIDLabelKey          = "agyn.io/workload-id"
+	workloadKeyLabelKey         = "workload_key"
+	volumeKeyLabelKey           = "volume_key"
+	pvcAnnotationKey            = "agyn.io/pvc-names"
+	secretAnnotationKey         = "agyn.io/pull-secret-names"
+	inlineFilesVolumeName       = "inline-files"
+	touchedAtAnnotationKey      = "agyn.io/touched-at"
 )
 
 // Server implements the RunnerService gRPC API against the Kubernetes API.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ const (
 	volumeKeyLabelKey      = "volume_key"
 	pvcAnnotationKey       = "agyn.io/pvc-names"
 	secretAnnotationKey    = "agyn.io/pull-secret-names"
+	inlineFilesVolumeName  = "inline-files"
 	touchedAtAnnotationKey = "agyn.io/touched-at"
 )
 

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -414,8 +414,9 @@ func (s *Server) TouchWorkload(ctx context.Context, req *runnerv1.TouchWorkloadR
 
 func buildLabels(workloadID string, additional map[string]string, explicit map[string]string) (map[string]string, error) {
 	labels := map[string]string{
-		managedByLabelKey:  managedByLabelValue,
-		workloadIDLabelKey: workloadID,
+		managedByLabelKey:         managedByLabelValue,
+		workloadManagedByLabelKey: workloadManagedByLabelValue,
+		workloadIDLabelKey:        workloadID,
 	}
 
 	for key, value := range additional {
@@ -451,7 +452,7 @@ func addLabel(target map[string]string, labelKey, value string) error {
 	if labelKey == "" {
 		return fmt.Errorf("empty label key")
 	}
-	if labelKey == managedByLabelKey || labelKey == workloadIDLabelKey {
+	if labelKey == managedByLabelKey || labelKey == workloadManagedByLabelKey || labelKey == workloadIDLabelKey {
 		return fmt.Errorf("reserved label key %q", labelKey)
 	}
 	if errs := validation.IsQualifiedName(labelKey); len(errs) > 0 {

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -70,8 +72,29 @@ func (s *Server) StartWorkload(ctx context.Context, req *runnerv1.StartWorkloadR
 		return nil, err
 	}
 
-	containers, initContainers, sidecarNames, err := buildContainers(req, volumes)
+	inlineFiles, err := validateInlineFiles(req)
 	if err != nil {
+		s.deleteImagePullSecrets(ctx, workloadID, secretNames)
+		return nil, err
+	}
+	inlineSecretName, inlineFileKeys, err := s.createInlineFilesSecret(ctx, workloadID, inlineFiles)
+	if err != nil {
+		s.deleteImagePullSecrets(ctx, workloadID, secretNames)
+		return nil, err
+	}
+	if inlineSecretName != "" {
+		secretNames = append(secretNames, inlineSecretName)
+		volumes = append(volumes, corev1.Volume{
+			Name: inlineFilesVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: inlineSecretName},
+			},
+		})
+	}
+
+	containers, initContainers, sidecarNames, err := buildContainers(req, volumes, inlineFileKeys)
+	if err != nil {
+		s.deleteImagePullSecrets(ctx, workloadID, secretNames)
 		return nil, err
 	}
 	hostUsers := capabilityPlan.apply(&containers, &initContainers, &volumes, &sidecarNames)
@@ -660,7 +683,7 @@ func (s *Server) ensurePVC(ctx context.Context, volume *runnerv1.VolumeSpec, lab
 	return pvcName, nil
 }
 
-func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume) ([]corev1.Container, []corev1.Container, []string, error) {
+func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume, inlineFileKeys map[string]string) ([]corev1.Container, []corev1.Container, []string, error) {
 	volumeLookup := make(map[string]struct{}, len(volumes))
 	for _, volume := range volumes {
 		volumeLookup[volume.Name] = struct{}{}
@@ -670,7 +693,7 @@ func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume
 	initContainers := make([]corev1.Container, 0, len(req.InitContainers))
 	nameLookup := make(map[string]struct{}, 1+len(req.Sidecars)+len(req.InitContainers))
 
-	mainContainer, err := buildContainer(req.Main, "main", volumeLookup)
+	mainContainer, err := buildContainer(req.Main, "main", volumeLookup, inlineFileKeys)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -679,7 +702,7 @@ func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume
 
 	sidecarNames := make([]string, 0, len(req.Sidecars))
 	for idx, sidecar := range req.Sidecars {
-		container, err := buildContainer(sidecar, fmt.Sprintf("sidecar-%d", idx+1), volumeLookup)
+		container, err := buildContainer(sidecar, fmt.Sprintf("sidecar-%d", idx+1), volumeLookup, inlineFileKeys)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -692,7 +715,7 @@ func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume
 	}
 
 	for idx, initContainer := range req.InitContainers {
-		container, err := buildContainer(initContainer, fmt.Sprintf("init-%d", idx+1), volumeLookup)
+		container, err := buildContainer(initContainer, fmt.Sprintf("init-%d", idx+1), volumeLookup, inlineFileKeys)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -706,7 +729,7 @@ func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume
 	return containers, initContainers, sidecarNames, nil
 }
 
-func buildContainer(spec *runnerv1.ContainerSpec, fallbackName string, volumeLookup map[string]struct{}) (corev1.Container, error) {
+func buildContainer(spec *runnerv1.ContainerSpec, fallbackName string, volumeLookup map[string]struct{}, inlineFileKeys map[string]string) (corev1.Container, error) {
 	if spec == nil {
 		return corev1.Container{}, status.Error(codes.InvalidArgument, "container_spec_required")
 	}
@@ -722,7 +745,7 @@ func buildContainer(spec *runnerv1.ContainerSpec, fallbackName string, volumeLoo
 		return corev1.Container{}, status.Error(codes.InvalidArgument, "container_image_required")
 	}
 
-	volumeMounts := make([]corev1.VolumeMount, 0, len(spec.Mounts))
+	volumeMounts := make([]corev1.VolumeMount, 0, len(spec.Mounts)+len(spec.InlineFileMounts))
 	for _, mount := range spec.Mounts {
 		if mount == nil {
 			continue
@@ -742,6 +765,23 @@ func buildContainer(spec *runnerv1.ContainerSpec, fallbackName string, volumeLoo
 			Name:      volumeName,
 			MountPath: mountPath,
 			ReadOnly:  mount.ReadOnly,
+		})
+	}
+
+	for _, mount := range spec.InlineFileMounts {
+		if mount == nil {
+			continue
+		}
+		mountPath := strings.TrimSpace(mount.GetPath())
+		secretKey, ok := inlineFileKeys[mountPath]
+		if !ok {
+			return corev1.Container{}, status.Errorf(codes.InvalidArgument, "inline_file_not_defined: %s", mountPath)
+		}
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      inlineFilesVolumeName,
+			MountPath: mountPath,
+			SubPath:   secretKey,
+			ReadOnly:  true,
 		})
 	}
 
@@ -868,4 +908,107 @@ func mountsForPod(pod *corev1.Pod, mainContainerName string) []*runnerv1.TargetM
 	}
 
 	return mounts
+}
+
+func validateInlineFiles(req *runnerv1.StartWorkloadRequest) (map[string][]byte, error) {
+	inlineFiles := req.GetInlineFiles()
+	if len(inlineFiles) == 0 {
+		if hasInlineFileMounts(req) {
+			return nil, status.Error(codes.InvalidArgument, "inline_file_not_defined")
+		}
+		return nil, nil
+	}
+
+	for filePath := range inlineFiles {
+		if err := validateInlineFilePath(filePath); err != nil {
+			return nil, err
+		}
+	}
+
+	referenced := make(map[string]struct{})
+	containers := append([]*runnerv1.ContainerSpec{req.GetMain()}, req.GetSidecars()...)
+	containers = append(containers, req.GetInitContainers()...)
+	for _, container := range containers {
+		if container == nil {
+			continue
+		}
+		for _, mount := range container.GetInlineFileMounts() {
+			if mount == nil {
+				continue
+			}
+			mountPath := strings.TrimSpace(mount.GetPath())
+			if err := validateInlineFilePath(mountPath); err != nil {
+				return nil, err
+			}
+			if _, ok := inlineFiles[mountPath]; !ok {
+				return nil, status.Errorf(codes.InvalidArgument, "inline_file_not_defined: %s", mountPath)
+			}
+			referenced[mountPath] = struct{}{}
+		}
+	}
+
+	for filePath := range inlineFiles {
+		if _, ok := referenced[filePath]; !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "inline_file_not_referenced: %s", filePath)
+		}
+	}
+
+	return inlineFiles, nil
+}
+
+func hasInlineFileMounts(req *runnerv1.StartWorkloadRequest) bool {
+	containers := append([]*runnerv1.ContainerSpec{req.GetMain()}, req.GetSidecars()...)
+	containers = append(containers, req.GetInitContainers()...)
+	for _, container := range containers {
+		if len(container.GetInlineFileMounts()) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func validateInlineFilePath(filePath string) error {
+	if filePath == "" || !path.IsAbs(filePath) || path.Clean(filePath) != filePath {
+		return status.Errorf(codes.InvalidArgument, "inline_file_path_invalid: %s", filePath)
+	}
+	return nil
+}
+
+func (s *Server) createInlineFilesSecret(ctx context.Context, workloadID string, inlineFiles map[string][]byte) (string, map[string]string, error) {
+	if len(inlineFiles) == 0 {
+		return "", nil, nil
+	}
+
+	paths := make([]string, 0, len(inlineFiles))
+	for filePath := range inlineFiles {
+		paths = append(paths, filePath)
+	}
+	sort.Strings(paths)
+
+	data := make(map[string][]byte, len(paths))
+	keys := make(map[string]string, len(paths))
+	for idx, filePath := range paths {
+		key := fmt.Sprintf("inline-file-%d", idx)
+		data[key] = append([]byte(nil), inlineFiles[filePath]...)
+		keys[filePath] = key
+	}
+
+	secretName := fmt.Sprintf("workload-%s-inline-files", workloadID)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: s.namespace,
+			Labels: map[string]string{
+				managedByLabelKey:  managedByLabelValue,
+				workloadIDLabelKey: workloadID,
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: data,
+	}
+	if _, err := s.clientset.CoreV1().Secrets(s.namespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
+		return "", nil, grpcErrorFromKube(s.logger, err, codes.Internal)
+	}
+
+	return secretName, keys, nil
 }

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -32,10 +32,11 @@ func TestBuildLabelsFiltersAndValidates(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		managedByLabelKey:   managedByLabelValue,
-		workloadIDLabelKey:  "uuid-1",
-		workloadKeyLabelKey: "workload-1",
-		"team":              "core",
+		managedByLabelKey:         managedByLabelValue,
+		workloadManagedByLabelKey: workloadManagedByLabelValue,
+		workloadIDLabelKey:        "uuid-1",
+		workloadKeyLabelKey:       "workload-1",
+		"team":                    "core",
 	}
 	if !reflect.DeepEqual(labels, expected) {
 		t.Fatalf("labels mismatch: got %#v want %#v", labels, expected)
@@ -59,9 +60,11 @@ func TestBuildLabelsRejectsInvalidExplicitLabel(t *testing.T) {
 }
 
 func TestBuildLabelsRejectsReservedLabel(t *testing.T) {
-	_, err := buildLabels("uuid-1", nil, map[string]string{managedByLabelKey: "override"})
-	if err == nil {
-		t.Fatalf("expected error for reserved label key")
+	for _, key := range []string{managedByLabelKey, workloadManagedByLabelKey} {
+		_, err := buildLabels("uuid-1", nil, map[string]string{key: "override"})
+		if err == nil {
+			t.Fatalf("expected error for reserved label key %s", key)
+		}
 	}
 }
 
@@ -345,6 +348,9 @@ func TestStartWorkloadUsesProvidedWorkloadID(t *testing.T) {
 	}
 	if pod.Labels[workloadIDLabelKey] != workloadID {
 		t.Fatalf("expected workload label %q, got %q", workloadID, pod.Labels[workloadIDLabelKey])
+	}
+	if pod.Labels[workloadManagedByLabelKey] != workloadManagedByLabelValue {
+		t.Fatalf("expected workload managed-by label %q, got %q", workloadManagedByLabelValue, pod.Labels[workloadManagedByLabelKey])
 	}
 }
 
@@ -1025,6 +1031,9 @@ func TestStartWorkloadAppliesLabelsToPodAndPVC(t *testing.T) {
 	}
 	if pod.Labels[managedByLabelKey] != managedByLabelValue {
 		t.Fatalf("expected managed-by label %q, got %q", managedByLabelValue, pod.Labels[managedByLabelKey])
+	}
+	if pod.Labels[workloadManagedByLabelKey] != workloadManagedByLabelValue {
+		t.Fatalf("expected workload managed-by label %q, got %q", workloadManagedByLabelValue, pod.Labels[workloadManagedByLabelKey])
 	}
 	if pod.Labels[workloadIDLabelKey] != resp.Id {
 		t.Fatalf("expected workload id label %q, got %q", resp.Id, pod.Labels[workloadIDLabelKey])

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -103,7 +103,7 @@ func TestBuildContainersMapsMainSpec(t *testing.T) {
 		},
 	}
 
-	containers, initContainers, sidecars, err := buildContainers(req, nil)
+	containers, initContainers, sidecars, err := buildContainers(req, nil, nil)
 	if err != nil {
 		t.Fatalf("buildContainers returned error: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestBuildContainerMapsRequiredCapabilities(t *testing.T) {
 		Name:                 "main",
 		Image:                "busybox",
 		RequiredCapabilities: []string{"NET_ADMIN"},
-	}, "main", map[string]struct{}{})
+	}, "main", map[string]struct{}{}, nil)
 	if err != nil {
 		t.Fatalf("buildContainer returned error: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestBuildContainerOmitsSecurityContextWithoutRequiredCapabilities(t *testin
 	container, err := buildContainer(&runnerv1.ContainerSpec{
 		Name:  "main",
 		Image: "busybox",
-	}, "main", map[string]struct{}{})
+	}, "main", map[string]struct{}{}, nil)
 	if err != nil {
 		t.Fatalf("buildContainer returned error: %v", err)
 	}
@@ -166,7 +166,7 @@ func TestBuildContainerOmitsSecurityContextWithoutRequiredCapabilities(t *testin
 		Name:                 "main",
 		Image:                "busybox",
 		RequiredCapabilities: []string{},
-	}, "main", map[string]struct{}{})
+	}, "main", map[string]struct{}{}, nil)
 	if err != nil {
 		t.Fatalf("buildContainer returned error: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestBuildContainerOmitsSecurityContextForWhitespaceCapabilities(t *testing.
 		Name:                 "main",
 		Image:                "busybox",
 		RequiredCapabilities: []string{" ", ""},
-	}, "main", map[string]struct{}{})
+	}, "main", map[string]struct{}{}, nil)
 	if err != nil {
 		t.Fatalf("buildContainer returned error: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestBuildContainersRejectsDuplicateNames(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := buildContainers(req, nil)
+	_, _, _, err := buildContainers(req, nil, nil)
 	if err == nil {
 		t.Fatalf("expected duplicate container error")
 	}
@@ -215,7 +215,7 @@ func TestBuildContainersRejectsEntrypointWithSpaces(t *testing.T) {
 		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox", Entrypoint: "/bin/sh -c"},
 	}
 
-	_, _, _, err := buildContainers(req, nil)
+	_, _, _, err := buildContainers(req, nil, nil)
 	if err == nil {
 		t.Fatalf("expected entrypoint validation error")
 	}
@@ -236,7 +236,7 @@ func TestBuildContainersMapsInitRestartPolicy(t *testing.T) {
 		},
 	}
 
-	_, initContainers, _, err := buildContainers(req, nil)
+	_, initContainers, _, err := buildContainers(req, nil, nil)
 	if err != nil {
 		t.Fatalf("buildContainers returned error: %v", err)
 	}
@@ -259,7 +259,7 @@ func TestBuildContainersOmitsInitRestartPolicy(t *testing.T) {
 		},
 	}
 
-	_, initContainers, _, err := buildContainers(req, nil)
+	_, initContainers, _, err := buildContainers(req, nil, nil)
 	if err != nil {
 		t.Fatalf("buildContainers returned error: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestBuildContainersRejectsInitDuplicateNameWithMain(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := buildContainers(req, nil)
+	_, _, _, err := buildContainers(req, nil, nil)
 	if err == nil {
 		t.Fatalf("expected duplicate container error")
 	}
@@ -301,7 +301,7 @@ func TestBuildContainersRejectsInitDuplicateNames(t *testing.T) {
 		},
 	}
 
-	_, _, _, err := buildContainers(req, nil)
+	_, _, _, err := buildContainers(req, nil, nil)
 	if err == nil {
 		t.Fatalf("expected duplicate container error")
 	}
@@ -1534,4 +1534,142 @@ func assertSidecarInstance(t *testing.T, sidecars []*runnerv1.SidecarInstance, n
 		}
 	}
 	t.Fatalf("expected sidecar instance %s", name)
+}
+
+func TestStartWorkloadMountsInlineFiles(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+
+	ctx := context.Background()
+	req := &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{
+			Name:             "main",
+			Image:            "busybox",
+			InlineFileMounts: []*runnerv1.InlineFileMount{{Path: "/etc/agyn/egress-ca/ca.crt"}},
+		},
+		Sidecars: []*runnerv1.ContainerSpec{{
+			Name:             "sidecar",
+			Image:            "busybox",
+			InlineFileMounts: []*runnerv1.InlineFileMount{{Path: "/etc/agyn/egress-ca/ca.crt"}},
+		}},
+		InlineFiles: map[string][]byte{
+			"/etc/agyn/egress-ca/ca.crt": []byte("cert"),
+		},
+	}
+
+	resp, err := server.StartWorkload(ctx, req)
+	if err != nil {
+		t.Fatalf("StartWorkload returned error: %v", err)
+	}
+
+	pod, err := clientset.CoreV1().Pods("default").Get(ctx, podNameFromID(resp.Id), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pod created: %v", err)
+	}
+	secretName := fmt.Sprintf("workload-%s-inline-files", resp.Id)
+	if pod.Annotations[secretAnnotationKey] != secretName {
+		t.Fatalf("expected inline secret annotation %q, got %q", secretName, pod.Annotations[secretAnnotationKey])
+	}
+	volume := findPodVolume(pod, inlineFilesVolumeName)
+	if volume == nil || volume.Secret == nil || volume.Secret.SecretName != secretName {
+		t.Fatalf("expected inline files secret volume")
+	}
+	assertInlineVolumeMount(t, pod.Spec.Containers[0], "/etc/agyn/egress-ca/ca.crt")
+	assertInlineVolumeMount(t, pod.Spec.Containers[1], "/etc/agyn/egress-ca/ca.crt")
+
+	secret, err := clientset.CoreV1().Secrets("default").Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected inline secret: %v", err)
+	}
+	if string(secret.Data["inline-file-0"]) != "cert" {
+		t.Fatalf("expected inline file secret data")
+	}
+}
+
+func TestStartWorkloadRejectsInvalidInlineFiles(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *runnerv1.StartWorkloadRequest
+		want string
+	}{
+		{
+			name: "mount without file",
+			req: &runnerv1.StartWorkloadRequest{Main: &runnerv1.ContainerSpec{
+				Name: "main", Image: "busybox", InlineFileMounts: []*runnerv1.InlineFileMount{{Path: "/file"}},
+			}},
+			want: "inline_file_not_defined",
+		},
+		{
+			name: "unreferenced file",
+			req: &runnerv1.StartWorkloadRequest{
+				Main:        &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+				InlineFiles: map[string][]byte{"/file": []byte("data")},
+			},
+			want: "inline_file_not_referenced",
+		},
+		{
+			name: "non absolute file",
+			req: &runnerv1.StartWorkloadRequest{
+				Main:        &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+				InlineFiles: map[string][]byte{"file": []byte("data")},
+			},
+			want: "inline_file_path_invalid",
+		},
+		{
+			name: "unclean mount",
+			req: &runnerv1.StartWorkloadRequest{
+				Main:        &runnerv1.ContainerSpec{Name: "main", Image: "busybox", InlineFileMounts: []*runnerv1.InlineFileMount{{Path: "/dir/../file"}}},
+				InlineFiles: map[string][]byte{"/file": []byte("data")},
+			},
+			want: "inline_file_path_invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			server := New(Options{Clientset: clientset, Namespace: "default", StorageSize: "1Gi", Logger: zap.NewNop()})
+			_, err := server.StartWorkload(context.Background(), tt.req)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != codes.InvalidArgument {
+				t.Fatalf("expected invalid argument, got %v", err)
+			}
+			if !strings.Contains(st.Message(), tt.want) {
+				t.Fatalf("expected %q in error, got %q", tt.want, st.Message())
+			}
+		})
+	}
+}
+
+func findPodVolume(pod *corev1.Pod, name string) *corev1.Volume {
+	for idx := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[idx].Name == name {
+			return &pod.Spec.Volumes[idx]
+		}
+	}
+	return nil
+}
+
+func assertInlineVolumeMount(t *testing.T, container corev1.Container, mountPath string) {
+	t.Helper()
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == inlineFilesVolumeName && mount.MountPath == mountPath {
+			if mount.SubPath == "" {
+				t.Fatalf("expected inline file subPath")
+			}
+			if !mount.ReadOnly {
+				t.Fatalf("expected inline file read-only mount")
+			}
+			return
+		}
+	}
+	t.Fatalf("container %s missing inline mount %s", container.Name, mountPath)
 }


### PR DESCRIPTION
## Summary
- Validates `StartWorkloadRequest.inline_files` and per-container `inline_file_mounts` for absolute clean paths, defined references, and no unreferenced files.
- Materializes inline files as one per-workload Secret and mounts requested files read-only with `subPath` into opted-in containers.
- Cleans up inline file Secrets through the existing workload secret cleanup path.
- Adds a Helm workload egress NetworkPolicy template selecting `agyn.dev/managed-by=agents-orchestrator` and documenting install-time CIDR configuration.

References agynio/architecture#151.
Closes #69.

## Validation
- `buf generate --include-imports` — passed
- `CGO_ENABLED=0 go test ./...` — passed=86 failed=0 skipped=0
- `CGO_ENABLED=0 go build ./...` — passed
- `CGO_ENABLED=0 go vet ./...` — passed with no errors
- `helm lint charts/k8s-runner` — passed with no errors
- `helm template test charts/k8s-runner --set workloadEgressNetworkPolicy.enabled=true --set workloadEgressNetworkPolicy.blockedCIDRs[0]=10.244.0.0/16 --set workloadEgressNetworkPolicy.blockedCIDRs[1]=10.96.0.0/12` — passed