### PR TITLE
feat: enable workload egress policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ any additional internal CIDRs in that list.
 
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.
+
+## Workload egress NetworkPolicy
+
+The chart installs `agent-workload-egress` by default in the workload namespace.
+It selects pods labeled `agyn.dev/managed-by: agents-orchestrator`, allows DNS,
+allows the OpenZiti tunnel CIDR (`100.64.0.0/10`), and allows public internet
+egress while excluding private, link-local, and loopback CIDRs. Override
+`workloadEgressNetworkPolicy.blockedCIDRs` to include cluster Pod/Service CIDRs
+or other operator-declared internal ranges for a production cluster.

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -52,7 +52,7 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
-  enabled: false
+  enabled: true
   fsGroup: null
 
 securityContext:
@@ -190,7 +190,7 @@ metrics:
 workloadNamespace: agyn-workloads
 
 workloadEgressNetworkPolicy:
-  enabled: false
+  enabled: true
   name: agent-workload-egress
   podSelectorLabels:
     agyn.dev/managed-by: agents-orchestrator
@@ -201,4 +201,9 @@ workloadEgressNetworkPolicy:
     podSelector:
       k8s-app: kube-dns
   publicInternetCIDR: 0.0.0.0/0
-  blockedCIDRs: []
+  blockedCIDRs:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+    - 169.254.0.0/16
+    - 127.0.0.0/8


### PR DESCRIPTION
## Summary
- Enable workload egress NetworkPolicy by default.
- Configure default blocked cluster/internal CIDRs while preserving DNS, OpenZiti, and public internet egress behavior.
- Document the default policy contract for runner installs.

Relates to agynio/egress#9.

## Validation
- `rm -rf internal/.gen` -> passed.
- `buf generate --include-imports` -> passed.
- `go test ./...` -> passed: Go packages 2 passed / 0 failed / 0 skipped; remaining packages had no test files.
- `go build ./...` -> passed.
- `helm dependency update charts/k8s-runner` -> passed.
- `helm lint charts/k8s-runner` -> passed: 1 chart linted / 0 failed.
- `helm template k8s-runner charts/k8s-runner` -> passed.
- `git diff --check` -> passed with no whitespace errors.
