### PR TITLE
feat(chart): expose egress CIDR values

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ The Helm chart can install the static egress NetworkPolicy used by egress v1.
 Enable `workloadEgressNetworkPolicy.enabled` and set `workloadNamespace` to the
 namespace where runner-created workload pods run. The policy selects workload
 pods with `agyn.dev/managed-by=agents-orchestrator`, allows OpenZiti synthetic
-addresses (`100.64.0.0/10`), cluster DNS, and public internet, and excludes the
-CIDRs listed in `workloadEgressNetworkPolicy.blockedCIDRs` from public internet
-egress. Operators should include the cluster pod CIDR, cluster service CIDR, and
-any additional internal CIDRs in that list.
+addresses (`100.64.0.0/10`), cluster DNS, and public internet, and excludes
+`workloadEgressNetworkPolicy.clusterPodCIDR`,
+`workloadEgressNetworkPolicy.clusterServiceCIDR`, and
+`workloadEgressNetworkPolicy.additionalInternalCIDRs` from public internet
+egress. `blockedCIDRs` remains as a deprecated compatibility alias.
 
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.
@@ -83,6 +84,7 @@ ServiceAccount does not need `networkpolicies` RBAC.
 The chart installs `agent-workload-egress` by default in the workload namespace.
 It selects pods labeled `agyn.dev/managed-by: agents-orchestrator`, allows DNS,
 allows the OpenZiti tunnel CIDR (`100.64.0.0/10`), and allows public internet
-egress while excluding private, link-local, and loopback CIDRs. Override
-`workloadEgressNetworkPolicy.blockedCIDRs` to include cluster Pod/Service CIDRs
-or other operator-declared internal ranges for a production cluster.
+egress while excluding configured cluster and internal CIDRs. Set
+`workloadEgressNetworkPolicy.clusterPodCIDR`,
+`workloadEgressNetworkPolicy.clusterServiceCIDR`, and
+`workloadEgressNetworkPolicy.additionalInternalCIDRs` for a production cluster.

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -1,4 +1,17 @@
 {{- if .Values.workloadEgressNetworkPolicy.enabled }}
+{{- $excludedCIDRs := list -}}
+{{- with .Values.workloadEgressNetworkPolicy.clusterPodCIDR }}
+{{- $excludedCIDRs = append $excludedCIDRs . -}}
+{{- end }}
+{{- with .Values.workloadEgressNetworkPolicy.clusterServiceCIDR }}
+{{- $excludedCIDRs = append $excludedCIDRs . -}}
+{{- end }}
+{{- range .Values.workloadEgressNetworkPolicy.additionalInternalCIDRs }}
+{{- $excludedCIDRs = append $excludedCIDRs . -}}
+{{- end }}
+{{- range .Values.workloadEgressNetworkPolicy.blockedCIDRs }}
+{{- $excludedCIDRs = append $excludedCIDRs . -}}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -31,7 +44,7 @@ spec:
     - to:
         - ipBlock:
             cidr: {{ .Values.workloadEgressNetworkPolicy.publicInternetCIDR | quote }}
-            {{- with .Values.workloadEgressNetworkPolicy.blockedCIDRs }}
+            {{- with $excludedCIDRs }}
             except:
               {{- toYaml . | nindent 14 }}
             {{- end }}

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -201,9 +201,18 @@ workloadEgressNetworkPolicy:
     podSelector:
       k8s-app: kube-dns
   publicInternetCIDR: 0.0.0.0/0
-  blockedCIDRs:
+  # Explicit cluster Pod CIDR to exclude from workload public-internet egress.
+  clusterPodCIDR: ""
+  # Explicit cluster Service CIDR to exclude from workload public-internet egress.
+  clusterServiceCIDR: ""
+  # Additional operator-declared internal CIDRs to exclude from workload public-internet egress.
+  additionalInternalCIDRs:
     - 10.0.0.0/8
     - 172.16.0.0/12
     - 192.168.0.0/16
     - 169.254.0.0/16
     - 127.0.0.0/8
+  # Deprecated compatibility alias. Prefer clusterPodCIDR, clusterServiceCIDR,
+  # and additionalInternalCIDRs.
+  blockedCIDRs:
+    []


### PR DESCRIPTION
## Summary

Part of agynio/architecture#156.

Affected repo: `agynio/k8s-runner`.

- Added explicit Helm values for workload egress NetworkPolicy `clusterPodCIDR`, `clusterServiceCIDR`, and `additionalInternalCIDRs`.
- Rendered NetworkPolicy `ipBlock.except` entries from those values.
- Kept `blockedCIDRs` as a deprecated compatibility alias.
- Updated chart values comments and README documentation.

## Test & lint summary

- `buf generate --include-imports --template buf.gen.yaml -o .`: passed.
- `CGO_ENABLED=0 go test ./...`: passed.
  - Tests: 2 Go packages passed, 0 failed, 0 skipped.
- `CGO_ENABLED=0 go vet ./...`: passed with no errors.
- `helm dependency update charts/k8s-runner`: passed.
- `helm lint charts/k8s-runner`: 1 chart linted, 0 failed.
- `helm template k8s-runner charts/k8s-runner`: passed.

## Notes

End-to-end platform validation from agynio/architecture#156 was not run locally because it requires the full deployed platform, OpenZiti, agents, cert-manager, metering/tracing, and external service credentials.