### PR TITLE
Allow workload egress for Ziti enrollment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           go-version: '1.25.x'
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Verify Helm chart
+        run: scripts/verify-workload-egress-networkpolicy.sh
+
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,12 @@ egress. `blockedCIDRs` remains as a deprecated compatibility alias.
 Ziti underlay egress is configured with first-class chart values. Enable
 `zitiWorkloadDNS` to allow workload pods to reach the Ziti workload DNS pods on
 TCP/UDP 53. Configure `zitiUnderlay.endpoints` with explicit service ClusterIP
-`/32` rules for the controller and router underlay endpoints returned by
-`ziti-workload-dns`. This keeps `.ziti` application traffic on the overlay while
-allowing only the underlay endpoints required for sidecar startup:
+`/32` rules for the enrollment controller, runtime Istio ingress gateway, and
+router underlay endpoints returned by `ziti-workload-dns`. Runtime
+`ziti.<base-domain>:443` resolves to the Istio ingress gateway so TLS
+passthrough can route SNI to the controller client service. This keeps `.ziti`
+application traffic on the overlay while allowing only the underlay endpoints
+required for sidecar startup:
 
 ```yaml
 workloadEgressNetworkPolicy:
@@ -92,16 +95,22 @@ workloadEgressNetworkPolicy:
       - name: controller
         cidr: "10.43.245.186/32"
         port: 2496
+      - name: ingress-gateway
+        cidr: "10.43.245.188/32"
+        port: 443
       - name: router
         cidr: "10.43.245.187/32"
         port: 2496
 ```
 
-Bootstrap should derive the controller and router underlay endpoint CIDRs from
-the live `ziti-controller-client` and `ziti-router-edge` ClusterIPs and set
-ports to the configured OpenZiti underlay ports. The deprecated
-`zitiControllerEnrollment` value remains for enrollment-only compatibility, but
-new bootstrap config should use `zitiUnderlay.endpoints`.
+Bootstrap should derive the underlay endpoint CIDRs from the live
+`ziti-controller-client`, `istio-ingressgateway`, and `ziti-router-edge`
+ClusterIPs. Set the controller and router ports to the configured OpenZiti
+underlay port, and set the runtime ingress gateway port to `443`. The deprecated
+`zitiControllerEnrollment` and `zitiRuntimeIngressGateway` values remain as
+named compatibility helpers for deployments that prefer fixed keys, but new
+bootstrap config should use `zitiUnderlay.endpoints` for the complete endpoint
+set.
 
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ ClusterIPs. For the runtime ingress gateway endpoint, bootstrap should also
 set endpoint pod CIDRs and the Istio ingress gateway namespace/pod selectors
 when available so CNIs can follow endpoint pods instead of only the Service
 ClusterIP. Set the controller and router ports to the configured
-OpenZiti underlay port, and set the runtime ingress gateway port to `443`. The
-deprecated `zitiControllerEnrollment` and `zitiRuntimeIngressGateway` values
-remain as named compatibility helpers for deployments that prefer fixed keys,
-but new bootstrap config should use `zitiUnderlay.endpoints` for the complete
-endpoint set.
+OpenZiti underlay port, and set the runtime ingress gateway port to `443`.
+The deprecated `zitiControllerEnrollment` and `zitiRuntimeIngressGateway` values
+remain as named compatibility helpers for deployments that prefer fixed keys.
+`zitiRuntimeIngressGateway` accepts the same runtime backend CIDR and selector
+fields as `zitiUnderlay.endpoints`, but new bootstrap config should use
+`zitiUnderlay.endpoints` for the complete endpoint set.
 
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.

--- a/README.md
+++ b/README.md
@@ -76,25 +76,32 @@ addresses (`100.64.0.0/10`), cluster DNS, and public internet, and excludes
 `workloadEgressNetworkPolicy.additionalInternalCIDRs` from public internet
 egress. `blockedCIDRs` remains as a deprecated compatibility alias.
 
-Ziti enrollment egress is configured with first-class chart values. Enable
+Ziti underlay egress is configured with first-class chart values. Enable
 `zitiWorkloadDNS` to allow workload pods to reach the Ziti workload DNS pods on
-TCP/UDP 53. Enable `zitiControllerEnrollment` and set `cidr` to the
-`ziti-controller-client` ClusterIP as a `/32` so init containers can verify and
-enroll JWTs against the Ziti controller before the sidecar DNS path is running:
+TCP/UDP 53. Configure `zitiUnderlay.endpoints` with explicit service ClusterIP
+`/32` rules for the controller and router underlay endpoints returned by
+`ziti-workload-dns`. This keeps `.ziti` application traffic on the overlay while
+allowing only the underlay endpoints required for sidecar startup:
 
 ```yaml
 workloadEgressNetworkPolicy:
   zitiWorkloadDNS:
     enabled: true
-  zitiControllerEnrollment:
-    enabled: true
-    cidr: "10.43.245.186/32"
-    port: 2496
+  zitiUnderlay:
+    endpoints:
+      - name: controller
+        cidr: "10.43.245.186/32"
+        port: 2496
+      - name: router
+        cidr: "10.43.245.187/32"
+        port: 2496
 ```
 
-Bootstrap should derive `zitiControllerEnrollment.cidr` from the live
-`ziti-controller-client` ClusterIP and set `port` to the configured controller
-client port.
+Bootstrap should derive the controller and router underlay endpoint CIDRs from
+the live `ziti-controller-client` and `ziti-router-edge` ClusterIPs and set
+ports to the configured OpenZiti underlay ports. The deprecated
+`zitiControllerEnrollment` value remains for enrollment-only compatibility, but
+new bootstrap config should use `zitiUnderlay.endpoints`.
 
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ egress. `blockedCIDRs` remains as a deprecated compatibility alias.
 
 Ziti underlay egress is configured with first-class chart values. Enable
 `zitiWorkloadDNS` to allow workload pods to reach the Ziti workload DNS pods on
-TCP/UDP 53. Configure `zitiUnderlay.endpoints` with explicit service ClusterIP
-`/32` rules for the enrollment controller, runtime Istio ingress gateway, and
-router underlay endpoints returned by `ziti-workload-dns`. Runtime
-`ziti.<base-domain>:443` resolves to the Istio ingress gateway so TLS
-passthrough can route SNI to the controller client service. This keeps `.ziti`
-application traffic on the overlay while allowing only the underlay endpoints
-required for sidecar startup:
+TCP/UDP 53. Configure `zitiUnderlay.endpoints` for the enrollment controller,
+runtime Istio ingress gateway, and router underlay endpoints returned by
+`ziti-workload-dns`. Each endpoint can allow a concrete service ClusterIP `/32`,
+a namespace/pod selector, or both. Runtime `ziti.<base-domain>:443` resolves to
+the Istio ingress gateway so TLS passthrough can route SNI to the controller
+client service. This keeps `.ziti` application traffic on the overlay while
+allowing only the underlay endpoints required for sidecar startup:
 
 ```yaml
 workloadEgressNetworkPolicy:
@@ -97,6 +97,10 @@ workloadEgressNetworkPolicy:
         port: 2496
       - name: ingress-gateway
         cidr: "10.43.245.188/32"
+        namespaceSelector:
+          kubernetes.io/metadata.name: istio-system
+        podSelector:
+          istio: ingressgateway
         port: 443
       - name: router
         cidr: "10.43.245.187/32"
@@ -105,12 +109,15 @@ workloadEgressNetworkPolicy:
 
 Bootstrap should derive the underlay endpoint CIDRs from the live
 `ziti-controller-client`, `istio-ingressgateway`, and `ziti-router-edge`
-ClusterIPs. Set the controller and router ports to the configured OpenZiti
-underlay port, and set the runtime ingress gateway port to `443`. The deprecated
-`zitiControllerEnrollment` and `zitiRuntimeIngressGateway` values remain as
-named compatibility helpers for deployments that prefer fixed keys, but new
-bootstrap config should use `zitiUnderlay.endpoints` for the complete endpoint
-set.
+ClusterIPs. For the runtime ingress gateway endpoint, bootstrap should also set
+the Istio ingress gateway namespace selector and pod selector when available so
+CNIs that honor selector-backed egress can follow endpoint pods instead of only
+the Service ClusterIP. Set the controller and router ports to the configured
+OpenZiti underlay port, and set the runtime ingress gateway port to `443`. The
+deprecated `zitiControllerEnrollment` and `zitiRuntimeIngressGateway` values
+remain as named compatibility helpers for deployments that prefer fixed keys,
+but new bootstrap config should use `zitiUnderlay.endpoints` for the complete
+endpoint set.
 
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ Ziti underlay egress is configured with first-class chart values. Enable
 TCP/UDP 53. Configure `zitiUnderlay.endpoints` for the enrollment controller,
 runtime Istio ingress gateway, and router underlay endpoints returned by
 `ziti-workload-dns`. Each endpoint can allow a concrete service ClusterIP `/32`,
-a namespace/pod selector, or both. Runtime `ziti.<base-domain>:443` resolves to
+endpoint/backend pod CIDRs through `backendCIDRs`, a namespace/pod selector,
+or a combination. Runtime `ziti.<base-domain>:443` resolves to
 the Istio ingress gateway so TLS passthrough can route SNI to the controller
 client service. This keeps `.ziti` application traffic on the overlay while
 allowing only the underlay endpoints required for sidecar startup:
@@ -97,6 +98,8 @@ workloadEgressNetworkPolicy:
         port: 2496
       - name: ingress-gateway
         cidr: "10.43.245.188/32"
+        backendCIDRs:
+          - "10.42.2.4/32"
         namespaceSelector:
           kubernetes.io/metadata.name: istio-system
         podSelector:
@@ -109,10 +112,10 @@ workloadEgressNetworkPolicy:
 
 Bootstrap should derive the underlay endpoint CIDRs from the live
 `ziti-controller-client`, `istio-ingressgateway`, and `ziti-router-edge`
-ClusterIPs. For the runtime ingress gateway endpoint, bootstrap should also set
-the Istio ingress gateway namespace selector and pod selector when available so
-CNIs that honor selector-backed egress can follow endpoint pods instead of only
-the Service ClusterIP. Set the controller and router ports to the configured
+ClusterIPs. For the runtime ingress gateway endpoint, bootstrap should also
+set endpoint pod CIDRs and the Istio ingress gateway namespace/pod selectors
+when available so CNIs can follow endpoint pods instead of only the Service
+ClusterIP. Set the controller and router ports to the configured
 OpenZiti underlay port, and set the runtime ingress gateway port to `443`. The
 deprecated `zitiControllerEnrollment` and `zitiRuntimeIngressGateway` values
 remain as named compatibility helpers for deployments that prefer fixed keys,

--- a/README.md
+++ b/README.md
@@ -76,15 +76,25 @@ addresses (`100.64.0.0/10`), cluster DNS, and public internet, and excludes
 `workloadEgressNetworkPolicy.additionalInternalCIDRs` from public internet
 egress. `blockedCIDRs` remains as a deprecated compatibility alias.
 
+Ziti enrollment egress is configured with first-class chart values. Enable
+`zitiWorkloadDNS` to allow workload pods to reach the Ziti workload DNS pods on
+TCP/UDP 53. Enable `zitiControllerEnrollment` and set `cidr` to the
+`ziti-controller-client` ClusterIP as a `/32` so init containers can verify and
+enroll JWTs against the Ziti controller before the sidecar DNS path is running:
+
+```yaml
+workloadEgressNetworkPolicy:
+  zitiWorkloadDNS:
+    enabled: true
+  zitiControllerEnrollment:
+    enabled: true
+    cidr: "10.43.245.186/32"
+    port: 2496
+```
+
+Bootstrap should derive `zitiControllerEnrollment.cidr` from the live
+`ziti-controller-client` ClusterIP and set `port` to the configured controller
+client port.
+
 The runner runtime does not create or update NetworkPolicy resources, and its
 ServiceAccount does not need `networkpolicies` RBAC.
-
-## Workload egress NetworkPolicy
-
-The chart installs `agent-workload-egress` by default in the workload namespace.
-It selects pods labeled `agyn.dev/managed-by: agents-orchestrator`, allows DNS,
-allows the OpenZiti tunnel CIDR (`100.64.0.0/10`), and allows public internet
-egress while excluding configured cluster and internal CIDRs. Set
-`workloadEgressNetworkPolicy.clusterPodCIDR`,
-`workloadEgressNetworkPolicy.clusterServiceCIDR`, and
-`workloadEgressNetworkPolicy.additionalInternalCIDRs` for a production cluster.

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -1,71 +1,79 @@
 {{- if .Values.workloadEgressNetworkPolicy.enabled }}
+{{- $policy := .Values.workloadEgressNetworkPolicy -}}
 {{- $excludedCIDRs := list -}}
-{{- with .Values.workloadEgressNetworkPolicy.clusterPodCIDR }}
+{{- with $policy.clusterPodCIDR }}
 {{- $excludedCIDRs = append $excludedCIDRs . -}}
 {{- end }}
-{{- with .Values.workloadEgressNetworkPolicy.clusterServiceCIDR }}
+{{- with $policy.clusterServiceCIDR }}
 {{- $excludedCIDRs = append $excludedCIDRs . -}}
 {{- end }}
-{{- range .Values.workloadEgressNetworkPolicy.additionalInternalCIDRs }}
+{{- range $policy.additionalInternalCIDRs }}
 {{- $excludedCIDRs = append $excludedCIDRs . -}}
 {{- end }}
-{{- range .Values.workloadEgressNetworkPolicy.blockedCIDRs }}
+{{- range $policy.blockedCIDRs }}
 {{- $excludedCIDRs = append $excludedCIDRs . -}}
+{{- end }}
+{{- $zitiUnderlayEndpoints := list -}}
+{{- range $policy.zitiUnderlay.endpoints }}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints . -}}
+{{- end }}
+{{- if $policy.zitiControllerEnrollment.enabled }}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiControllerEnrollment" "cidr" $policy.zitiControllerEnrollment.cidr "port" $policy.zitiControllerEnrollment.port) -}}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ .Values.workloadEgressNetworkPolicy.name | quote }}
+  name: {{ $policy.name | quote }}
   namespace: {{ default .Release.Namespace .Values.workloadNamespace | quote }}
   labels:
     {{- include "service-base.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      {{- toYaml .Values.workloadEgressNetworkPolicy.podSelectorLabels | nindent 6 }}
+      {{- toYaml $policy.podSelectorLabels | nindent 6 }}
   policyTypes:
     - Egress
   egress:
     - to:
         - ipBlock:
-            cidr: {{ .Values.workloadEgressNetworkPolicy.openZitiCIDR | quote }}
+            cidr: {{ $policy.openZitiCIDR | quote }}
     - to:
         - namespaceSelector:
             matchLabels:
-              {{- toYaml .Values.workloadEgressNetworkPolicy.dns.namespaceSelector | nindent 14 }}
+              {{- toYaml $policy.dns.namespaceSelector | nindent 14 }}
           podSelector:
             matchLabels:
-              {{- toYaml .Values.workloadEgressNetworkPolicy.dns.podSelector | nindent 14 }}
+              {{- toYaml $policy.dns.podSelector | nindent 14 }}
       ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
           port: 53
-    {{- if .Values.workloadEgressNetworkPolicy.zitiWorkloadDNS.enabled }}
+    {{- if $policy.zitiWorkloadDNS.enabled }}
     - to:
         - namespaceSelector:
             matchLabels:
-              {{- toYaml .Values.workloadEgressNetworkPolicy.zitiWorkloadDNS.namespaceSelector | nindent 14 }}
+              {{- toYaml $policy.zitiWorkloadDNS.namespaceSelector | nindent 14 }}
           podSelector:
             matchLabels:
-              {{- toYaml .Values.workloadEgressNetworkPolicy.zitiWorkloadDNS.podSelector | nindent 14 }}
+              {{- toYaml $policy.zitiWorkloadDNS.podSelector | nindent 14 }}
       ports:
         - protocol: UDP
           port: 53
         - protocol: TCP
           port: 53
     {{- end }}
-    {{- if .Values.workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled }}
+    {{- range $endpoint := $zitiUnderlayEndpoints }}
     - to:
         - ipBlock:
-            cidr: {{ required "workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr is required when zitiControllerEnrollment is enabled" .Values.workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr | quote }}
+            cidr: {{ required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr is required" (default "unnamed" $endpoint.name)) $endpoint.cidr | quote }}
       ports:
         - protocol: TCP
-          port: {{ .Values.workloadEgressNetworkPolicy.zitiControllerEnrollment.port }}
+          port: {{ required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].port is required" (default "unnamed" $endpoint.name)) $endpoint.port }}
     {{- end }}
     - to:
         - ipBlock:
-            cidr: {{ .Values.workloadEgressNetworkPolicy.publicInternetCIDR | quote }}
+            cidr: {{ $policy.publicInternetCIDR | quote }}
             {{- with $excludedCIDRs }}
             except:
               {{- toYaml . | nindent 14 }}

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -25,7 +25,20 @@
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiControllerEnrollment" "cidr" $policy.zitiControllerEnrollment.cidr "port" $policy.zitiControllerEnrollment.port) -}}
 {{- end }}
 {{- if $policy.zitiRuntimeIngressGateway.enabled }}
-{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiRuntimeIngressGateway" "cidr" $policy.zitiRuntimeIngressGateway.cidr "port" $policy.zitiRuntimeIngressGateway.port) -}}
+{{- $zitiRuntimeIngressGateway := dict "name" "zitiRuntimeIngressGateway" "cidr" $policy.zitiRuntimeIngressGateway.cidr "port" $policy.zitiRuntimeIngressGateway.port -}}
+{{- with $policy.zitiRuntimeIngressGateway.backendCIDRs }}
+{{- $_ := set $zitiRuntimeIngressGateway "backendCIDRs" . -}}
+{{- end }}
+{{- with $policy.zitiRuntimeIngressGateway.namespaceSelector }}
+{{- $_ := set $zitiRuntimeIngressGateway "namespaceSelector" . -}}
+{{- end }}
+{{- with $policy.zitiRuntimeIngressGateway.podSelector }}
+{{- $_ := set $zitiRuntimeIngressGateway "podSelector" . -}}
+{{- end }}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints $zitiRuntimeIngressGateway -}}
+{{- range $cidr := $policy.zitiRuntimeIngressGateway.backendCIDRs }}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiRuntimeIngressGateway-backend" "cidr" $cidr "port" $policy.zitiRuntimeIngressGateway.port) -}}
+{{- end }}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -15,7 +15,11 @@
 {{- end }}
 {{- $zitiUnderlayEndpoints := list -}}
 {{- range $policy.zitiUnderlay.endpoints }}
-{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints . -}}
+{{- $baseEndpoint := . -}}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints $baseEndpoint -}}
+{{- range $cidr := $baseEndpoint.backendCIDRs }}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" (printf "%s-backend" (default "unnamed" $baseEndpoint.name)) "cidr" $cidr "port" $baseEndpoint.port) -}}
+{{- end }}
 {{- end }}
 {{- if $policy.zitiControllerEnrollment.enabled }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiControllerEnrollment" "cidr" $policy.zitiControllerEnrollment.cidr "port" $policy.zitiControllerEnrollment.port) -}}
@@ -67,8 +71,8 @@ spec:
           port: 53
     {{- end }}
     {{- range $endpoint := $zitiUnderlayEndpoints }}
-    {{- if not (or $endpoint.cidr $endpoint.namespaceSelector $endpoint.podSelector) }}
-    {{- required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr or selectors are required" (default "unnamed" $endpoint.name)) "" }}
+    {{- if not (or $endpoint.cidr $endpoint.backendCIDRs $endpoint.namespaceSelector $endpoint.podSelector) }}
+    {{- required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr, backendCIDRs, or selectors are required" (default "unnamed" $endpoint.name)) "" }}
     {{- end }}
     - to:
         {{- if $endpoint.cidr }}

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -67,9 +67,26 @@ spec:
           port: 53
     {{- end }}
     {{- range $endpoint := $zitiUnderlayEndpoints }}
+    {{- if not (or $endpoint.cidr $endpoint.namespaceSelector $endpoint.podSelector) }}
+    {{- required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr or selectors are required" (default "unnamed" $endpoint.name)) "" }}
+    {{- end }}
     - to:
+        {{- if $endpoint.cidr }}
         - ipBlock:
-            cidr: {{ required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr is required" (default "unnamed" $endpoint.name)) $endpoint.cidr | quote }}
+            cidr: {{ $endpoint.cidr | quote }}
+        {{- end }}
+        {{- if or $endpoint.namespaceSelector $endpoint.podSelector }}
+        - {{- with $endpoint.namespaceSelector }}
+          namespaceSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with $endpoint.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+          {{- end }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].port is required" (default "unnamed" $endpoint.name)) $endpoint.port }}

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -20,6 +20,9 @@
 {{- if $policy.zitiControllerEnrollment.enabled }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiControllerEnrollment" "cidr" $policy.zitiControllerEnrollment.cidr "port" $policy.zitiControllerEnrollment.port) -}}
 {{- end }}
+{{- if $policy.zitiRuntimeIngressGateway.enabled }}
+{{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiRuntimeIngressGateway" "cidr" $policy.zitiRuntimeIngressGateway.cidr "port" $policy.zitiRuntimeIngressGateway.port) -}}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -41,6 +41,28 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+    {{- if .Values.workloadEgressNetworkPolicy.zitiWorkloadDNS.enabled }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.workloadEgressNetworkPolicy.zitiWorkloadDNS.namespaceSelector | nindent 14 }}
+          podSelector:
+            matchLabels:
+              {{- toYaml .Values.workloadEgressNetworkPolicy.zitiWorkloadDNS.podSelector | nindent 14 }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if .Values.workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled }}
+    - to:
+        - ipBlock:
+            cidr: {{ required "workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr is required when zitiControllerEnrollment is enabled" .Values.workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.workloadEgressNetworkPolicy.zitiControllerEnrollment.port }}
+    {{- end }}
     - to:
         - ipBlock:
             cidr: {{ .Values.workloadEgressNetworkPolicy.publicInternetCIDR | quote }}

--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -16,12 +16,20 @@
 {{- $zitiUnderlayEndpoints := list -}}
 {{- range $policy.zitiUnderlay.endpoints }}
 {{- $baseEndpoint := . -}}
+{{- if not (or $baseEndpoint.cidr $baseEndpoint.backendCIDRs $baseEndpoint.namespaceSelector $baseEndpoint.podSelector) }}
+{{- required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr, backendCIDRs, or selectors are required" (default "unnamed" $baseEndpoint.name)) "" }}
+{{- end }}
+{{- if or $baseEndpoint.cidr $baseEndpoint.namespaceSelector $baseEndpoint.podSelector }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints $baseEndpoint -}}
+{{- end }}
 {{- range $cidr := $baseEndpoint.backendCIDRs }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" (printf "%s-backend" (default "unnamed" $baseEndpoint.name)) "cidr" $cidr "port" $baseEndpoint.port) -}}
 {{- end }}
 {{- end }}
 {{- if $policy.zitiControllerEnrollment.enabled }}
+{{- if not $policy.zitiControllerEnrollment.cidr }}
+{{- required "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr, backendCIDRs, or selectors are required" "" }}
+{{- end }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiControllerEnrollment" "cidr" $policy.zitiControllerEnrollment.cidr "port" $policy.zitiControllerEnrollment.port) -}}
 {{- end }}
 {{- if $policy.zitiRuntimeIngressGateway.enabled }}
@@ -35,7 +43,12 @@
 {{- with $policy.zitiRuntimeIngressGateway.podSelector }}
 {{- $_ := set $zitiRuntimeIngressGateway "podSelector" . -}}
 {{- end }}
+{{- if not (or $policy.zitiRuntimeIngressGateway.cidr $policy.zitiRuntimeIngressGateway.backendCIDRs $policy.zitiRuntimeIngressGateway.namespaceSelector $policy.zitiRuntimeIngressGateway.podSelector) }}
+{{- required "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiRuntimeIngressGateway].cidr, backendCIDRs, or selectors are required" "" }}
+{{- end }}
+{{- if or $zitiRuntimeIngressGateway.cidr $zitiRuntimeIngressGateway.namespaceSelector $zitiRuntimeIngressGateway.podSelector }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints $zitiRuntimeIngressGateway -}}
+{{- end }}
 {{- range $cidr := $policy.zitiRuntimeIngressGateway.backendCIDRs }}
 {{- $zitiUnderlayEndpoints = append $zitiUnderlayEndpoints (dict "name" "zitiRuntimeIngressGateway-backend" "cidr" $cidr "port" $policy.zitiRuntimeIngressGateway.port) -}}
 {{- end }}
@@ -84,8 +97,8 @@ spec:
           port: 53
     {{- end }}
     {{- range $endpoint := $zitiUnderlayEndpoints }}
-    {{- if not (or $endpoint.cidr $endpoint.backendCIDRs $endpoint.namespaceSelector $endpoint.podSelector) }}
-    {{- required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr, backendCIDRs, or selectors are required" (default "unnamed" $endpoint.name)) "" }}
+    {{- if not (or $endpoint.cidr $endpoint.namespaceSelector $endpoint.podSelector) }}
+    {{- required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].cidr or selectors are required" (default "unnamed" $endpoint.name)) "" }}
     {{- end }}
     - to:
         {{- if $endpoint.cidr }}

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -216,6 +216,7 @@ workloadEgressNetworkPolicy:
     #   port: 2496
     # - name: ingress-gateway
     #   cidr: ""
+    #   backendCIDRs: []
     #   namespaceSelector: {}
     #   podSelector: {}
     #   port: 443

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -233,6 +233,9 @@ workloadEgressNetworkPolicy:
   zitiRuntimeIngressGateway:
     enabled: false
     cidr: ""
+    backendCIDRs: []
+    namespaceSelector: {}
+    podSelector: {}
     port: 443
   publicInternetCIDR: 0.0.0.0/0
   # Explicit cluster Pod CIDR to exclude from workload public-internet egress.

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -211,12 +211,18 @@ workloadEgressNetworkPolicy:
     # Example:
     # - name: controller
     #   cidr: ""
+    #   namespaceSelector: {}
+    #   podSelector: {}
     #   port: 2496
     # - name: ingress-gateway
     #   cidr: ""
+    #   namespaceSelector: {}
+    #   podSelector: {}
     #   port: 443
     # - name: router
     #   cidr: ""
+    #   namespaceSelector: {}
+    #   podSelector: {}
     #   port: 2496
   # Deprecated compatibility alias. Prefer zitiUnderlay.endpoints.
   zitiControllerEnrollment:

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -212,6 +212,9 @@ workloadEgressNetworkPolicy:
     # - name: controller
     #   cidr: ""
     #   port: 2496
+    # - name: ingress-gateway
+    #   cidr: ""
+    #   port: 443
     # - name: router
     #   cidr: ""
     #   port: 2496
@@ -220,6 +223,10 @@ workloadEgressNetworkPolicy:
     enabled: false
     cidr: ""
     port: 2496
+  zitiRuntimeIngressGateway:
+    enabled: false
+    cidr: ""
+    port: 443
   publicInternetCIDR: 0.0.0.0/0
   # Explicit cluster Pod CIDR to exclude from workload public-internet egress.
   clusterPodCIDR: ""

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -200,6 +200,16 @@ workloadEgressNetworkPolicy:
       kubernetes.io/metadata.name: kube-system
     podSelector:
       k8s-app: kube-dns
+  zitiWorkloadDNS:
+    enabled: false
+    namespaceSelector:
+      kubernetes.io/metadata.name: ziti
+    podSelector:
+      app.kubernetes.io/name: ziti-workload-dns
+  zitiControllerEnrollment:
+    enabled: false
+    cidr: ""
+    port: 2496
   publicInternetCIDR: 0.0.0.0/0
   # Explicit cluster Pod CIDR to exclude from workload public-internet egress.
   clusterPodCIDR: ""

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -206,6 +206,16 @@ workloadEgressNetworkPolicy:
       kubernetes.io/metadata.name: ziti
     podSelector:
       app.kubernetes.io/name: ziti-workload-dns
+  zitiUnderlay:
+    endpoints: []
+    # Example:
+    # - name: controller
+    #   cidr: ""
+    #   port: 2496
+    # - name: router
+    #   cidr: ""
+    #   port: 2496
+  # Deprecated compatibility alias. Prefer zitiUnderlay.endpoints.
   zitiControllerEnrollment:
     enabled: false
     cidr: ""

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -65,6 +65,8 @@ workloadEgressNetworkPolicy:
     endpoints:
       - name: ingress-gateway
         cidr: 10.43.245.188/32
+        backendCIDRs:
+          - 10.42.2.4/32
         namespaceSelector:
           kubernetes.io/metadata.name: istio-system
         podSelector:
@@ -76,6 +78,7 @@ helm template k8s-runner "$chart_dir" \
   -f "$values_file" \
   >"$rendered"
 assert_contains 'cidr: "10.43.245.188/32"'
+assert_contains 'cidr: "10.42.2.4/32"'
 assert_contains 'kubernetes.io/metadata.name: istio-system'
 assert_contains 'istio: ingressgateway'
 assert_contains 'port: 443'
@@ -137,7 +140,7 @@ if helm template k8s-runner "$chart_dir" \
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[controller].cidr or selectors are required' "$error_log"; then
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[controller].cidr, backendCIDRs, or selectors are required' "$error_log"; then
   echo "expected missing underlay endpoint CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1
@@ -150,7 +153,7 @@ if helm template k8s-runner "$chart_dir" \
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr or selectors are required' "$error_log"; then
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr, backendCIDRs, or selectors are required' "$error_log"; then
   echo "expected missing deprecated controller CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1
@@ -163,7 +166,7 @@ if helm template k8s-runner "$chart_dir" \
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiRuntimeIngressGateway].cidr or selectors are required' "$error_log"; then
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiRuntimeIngressGateway].cidr, backendCIDRs, or selectors are required' "$error_log"; then
   echo "expected missing runtime ingress gateway CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -125,11 +125,17 @@ helm template k8s-runner "$chart_dir" \
   --set workloadEgressNetworkPolicy.zitiControllerEnrollment.port=2496 \
   --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.enabled=true \
   --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.cidr=10.43.245.188/32 \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.backendCIDRs[0]=10.42.2.4/32 \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.namespaceSelector.kubernetes\\.io/metadata\\.name=istio-system \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.podSelector.istio=ingressgateway \
   --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.port=443 \
   >"$rendered"
 assert_contains 'cidr: "10.43.245.186/32"'
 assert_contains 'port: 2496'
 assert_contains 'cidr: "10.43.245.188/32"'
+assert_contains 'cidr: "10.42.2.4/32"'
+assert_contains 'kubernetes.io/metadata.name: istio-system'
+assert_contains 'istio: ingressgateway'
 assert_contains 'port: 443'
 
 if helm template k8s-runner "$chart_dir" \

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -13,15 +13,26 @@ helm template k8s-runner "$chart_dir" \
   --set workloadNamespace=agyn-workloads \
   --set workloadEgressNetworkPolicy.enabled=true \
   --set workloadEgressNetworkPolicy.zitiWorkloadDNS.enabled=true \
-  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
-  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr=10.43.245.186/32 \
-  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.port=2496 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].name=controller \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].cidr=10.43.245.186/32 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].port=2496 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].name=router \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].cidr=10.43.245.187/32 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].port=2496 \
   >"$rendered"
 
 assert_contains() {
   local expected="$1"
   if ! grep -Fq -- "$expected" "$rendered"; then
     echo "expected rendered chart to contain: $expected" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local unexpected="$1"
+  if grep -Fq -- "$unexpected" "$rendered"; then
+    echo "expected rendered chart not to contain: $unexpected" >&2
     exit 1
   fi
 }
@@ -35,8 +46,10 @@ assert_contains 'k8s-app: kube-dns'
 assert_contains 'kubernetes.io/metadata.name: ziti'
 assert_contains 'app.kubernetes.io/name: ziti-workload-dns'
 assert_contains 'cidr: "10.43.245.186/32"'
+assert_contains 'cidr: "10.43.245.187/32"'
 assert_contains 'port: 2496'
 assert_contains 'cidr: "0.0.0.0/0"'
+assert_not_contains '10.0.0.0/8/32'
 
 udp_53_count="$(grep -F 'protocol: UDP' -A1 "$rendered" | grep -F 'port: 53' | wc -l | tr -d ' ')"
 tcp_53_count="$(grep -F 'protocol: TCP' -A1 "$rendered" | grep -F 'port: 53' | wc -l | tr -d ' ')"
@@ -45,15 +58,45 @@ if [[ "$udp_53_count" -lt 2 || "$tcp_53_count" -lt 2 ]]; then
   exit 1
 fi
 
-if helm template k8s-runner "$chart_dir" \
-  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
-  > /dev/null 2>"$error_log"; then
-  echo "expected helm template to fail when ziti controller enrollment CIDR is missing" >&2
+port_2496_count="$(grep -F 'port: 2496' "$rendered" | wc -l | tr -d ' ')"
+if [[ "$port_2496_count" -lt 2 ]]; then
+  echo "expected controller and router underlay TCP 2496 rules" >&2
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr is required when zitiControllerEnrollment is enabled' "$error_log"; then
-  echo "expected missing CIDR validation error" >&2
+helm template k8s-runner "$chart_dir" \
+  --set workloadNamespace=agyn-workloads \
+  --set workloadEgressNetworkPolicy.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr=10.43.245.186/32 \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.port=2496 \
+  >"$rendered"
+assert_contains 'cidr: "10.43.245.186/32"'
+assert_contains 'port: 2496'
+
+if helm template k8s-runner "$chart_dir" \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].name=controller \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].port=2496 \
+  > /dev/null 2>"$error_log"; then
+  echo "expected helm template to fail when ziti underlay endpoint CIDR is missing" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[controller].cidr is required' "$error_log"; then
+  echo "expected missing underlay endpoint CIDR validation error" >&2
+  cat "$error_log" >&2
+  exit 1
+fi
+
+if helm template k8s-runner "$chart_dir" \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
+  > /dev/null 2>"$error_log"; then
+  echo "expected helm template to fail when deprecated ziti controller enrollment CIDR is missing" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr is required' "$error_log"; then
+  echo "expected missing deprecated controller CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1
 fi

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -19,6 +19,9 @@ helm template k8s-runner "$chart_dir" \
   --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].name=router \
   --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].cidr=10.43.245.187/32 \
   --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].port=2496 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[2].name=ingress-gateway \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[2].cidr=10.43.245.188/32 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[2].port=443 \
   >"$rendered"
 
 assert_contains() {
@@ -47,7 +50,9 @@ assert_contains 'kubernetes.io/metadata.name: ziti'
 assert_contains 'app.kubernetes.io/name: ziti-workload-dns'
 assert_contains 'cidr: "10.43.245.186/32"'
 assert_contains 'cidr: "10.43.245.187/32"'
+assert_contains 'cidr: "10.43.245.188/32"'
 assert_contains 'port: 2496'
+assert_contains 'port: 443'
 assert_contains 'cidr: "0.0.0.0/0"'
 assert_not_contains '10.0.0.0/8/32'
 
@@ -64,15 +69,26 @@ if [[ "$port_2496_count" -lt 2 ]]; then
   exit 1
 fi
 
+port_443_count="$(grep -F 'port: 443' "$rendered" | wc -l | tr -d ' ')"
+if [[ "$port_443_count" -lt 1 ]]; then
+  echo "expected runtime Istio ingress gateway TCP 443 rule" >&2
+  exit 1
+fi
+
 helm template k8s-runner "$chart_dir" \
   --set workloadNamespace=agyn-workloads \
   --set workloadEgressNetworkPolicy.enabled=true \
   --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
   --set workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr=10.43.245.186/32 \
   --set workloadEgressNetworkPolicy.zitiControllerEnrollment.port=2496 \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.cidr=10.43.245.188/32 \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.port=443 \
   >"$rendered"
 assert_contains 'cidr: "10.43.245.186/32"'
 assert_contains 'port: 2496'
+assert_contains 'cidr: "10.43.245.188/32"'
+assert_contains 'port: 443'
 
 if helm template k8s-runner "$chart_dir" \
   --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].name=controller \
@@ -97,6 +113,19 @@ fi
 
 if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr is required' "$error_log"; then
   echo "expected missing deprecated controller CIDR validation error" >&2
+  cat "$error_log" >&2
+  exit 1
+fi
+
+if helm template k8s-runner "$chart_dir" \
+  --set workloadEgressNetworkPolicy.zitiRuntimeIngressGateway.enabled=true \
+  > /dev/null 2>"$error_log"; then
+  echo "expected helm template to fail when runtime ingress gateway CIDR is missing" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiRuntimeIngressGateway].cidr is required' "$error_log"; then
+  echo "expected missing runtime ingress gateway CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1
 fi

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="charts/k8s-runner"
+rendered="$(mktemp)"
+error_log="$(mktemp)"
+trap 'rm -f "$rendered" "$error_log"' EXIT
+
+helm dependency build "$chart_dir" >/dev/null
+helm lint "$chart_dir" >/dev/null
+
+helm template k8s-runner "$chart_dir" \
+  --set workloadNamespace=agyn-workloads \
+  --set workloadEgressNetworkPolicy.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiWorkloadDNS.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr=10.43.245.186/32 \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.port=2496 \
+  >"$rendered"
+
+assert_contains() {
+  local expected="$1"
+  if ! grep -Fq -- "$expected" "$rendered"; then
+    echo "expected rendered chart to contain: $expected" >&2
+    exit 1
+  fi
+}
+
+assert_contains 'kind: NetworkPolicy'
+assert_contains 'name: "agent-workload-egress"'
+assert_contains 'namespace: "agyn-workloads"'
+assert_contains 'cidr: "100.64.0.0/10"'
+assert_contains 'kubernetes.io/metadata.name: kube-system'
+assert_contains 'k8s-app: kube-dns'
+assert_contains 'kubernetes.io/metadata.name: ziti'
+assert_contains 'app.kubernetes.io/name: ziti-workload-dns'
+assert_contains 'cidr: "10.43.245.186/32"'
+assert_contains 'port: 2496'
+assert_contains 'cidr: "0.0.0.0/0"'
+
+udp_53_count="$(grep -F 'protocol: UDP' -A1 "$rendered" | grep -F 'port: 53' | wc -l | tr -d ' ')"
+tcp_53_count="$(grep -F 'protocol: TCP' -A1 "$rendered" | grep -F 'port: 53' | wc -l | tr -d ' ')"
+if [[ "$udp_53_count" -lt 2 || "$tcp_53_count" -lt 2 ]]; then
+  echo "expected at least two UDP/TCP 53 rules for kube-dns and ziti-workload-dns" >&2
+  exit 1
+fi
+
+if helm template k8s-runner "$chart_dir" \
+  --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true \
+  > /dev/null 2>"$error_log"; then
+  echo "expected helm template to fail when ziti controller enrollment CIDR is missing" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr is required when zitiControllerEnrollment is enabled' "$error_log"; then
+  echo "expected missing CIDR validation error" >&2
+  cat "$error_log" >&2
+  exit 1
+fi

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 chart_dir="charts/k8s-runner"
 rendered="$(mktemp)"
+values_file="$(mktemp)"
 error_log="$(mktemp)"
-trap 'rm -f "$rendered" "$error_log"' EXIT
+trap 'rm -f "$rendered" "$values_file" "$error_log"' EXIT
 
 helm dependency build "$chart_dir" >/dev/null
 helm lint "$chart_dir" >/dev/null
@@ -56,6 +57,44 @@ assert_contains 'port: 443'
 assert_contains 'cidr: "0.0.0.0/0"'
 assert_not_contains '10.0.0.0/8/32'
 
+cat >"$values_file" <<'VALUES'
+workloadNamespace: agyn-workloads
+workloadEgressNetworkPolicy:
+  enabled: true
+  zitiUnderlay:
+    endpoints:
+      - name: ingress-gateway
+        cidr: 10.43.245.188/32
+        namespaceSelector:
+          kubernetes.io/metadata.name: istio-system
+        podSelector:
+          istio: ingressgateway
+        port: 443
+VALUES
+
+helm template k8s-runner "$chart_dir" \
+  -f "$values_file" \
+  >"$rendered"
+assert_contains 'cidr: "10.43.245.188/32"'
+assert_contains 'kubernetes.io/metadata.name: istio-system'
+assert_contains 'istio: ingressgateway'
+assert_contains 'port: 443'
+
+helm template k8s-runner "$chart_dir" \
+  --set workloadNamespace=agyn-workloads \
+  --set workloadEgressNetworkPolicy.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiWorkloadDNS.enabled=true \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].name=controller \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].cidr=10.43.245.186/32 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[0].port=2496 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].name=router \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].cidr=10.43.245.187/32 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[1].port=2496 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[2].name=ingress-gateway \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[2].cidr=10.43.245.188/32 \
+  --set workloadEgressNetworkPolicy.zitiUnderlay.endpoints[2].port=443 \
+  >"$rendered"
+
 udp_53_count="$(grep -F 'protocol: UDP' -A1 "$rendered" | grep -F 'port: 53' | wc -l | tr -d ' ')"
 tcp_53_count="$(grep -F 'protocol: TCP' -A1 "$rendered" | grep -F 'port: 53' | wc -l | tr -d ' ')"
 if [[ "$udp_53_count" -lt 2 || "$tcp_53_count" -lt 2 ]]; then
@@ -98,7 +137,7 @@ if helm template k8s-runner "$chart_dir" \
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[controller].cidr is required' "$error_log"; then
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[controller].cidr or selectors are required' "$error_log"; then
   echo "expected missing underlay endpoint CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1
@@ -111,7 +150,7 @@ if helm template k8s-runner "$chart_dir" \
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr is required' "$error_log"; then
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiControllerEnrollment].cidr or selectors are required' "$error_log"; then
   echo "expected missing deprecated controller CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1
@@ -124,7 +163,7 @@ if helm template k8s-runner "$chart_dir" \
   exit 1
 fi
 
-if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiRuntimeIngressGateway].cidr is required' "$error_log"; then
+if ! grep -Fq 'workloadEgressNetworkPolicy.zitiUnderlay.endpoints[zitiRuntimeIngressGateway].cidr or selectors are required' "$error_log"; then
   echo "expected missing runtime ingress gateway CIDR validation error" >&2
   cat "$error_log" >&2
   exit 1

--- a/scripts/verify-workload-egress-networkpolicy.sh
+++ b/scripts/verify-workload-egress-networkpolicy.sh
@@ -41,6 +41,18 @@ assert_not_contains() {
   fi
 }
 
+assert_no_empty_to_blocks() {
+  if ! awk '
+    /^    - to:$/ { in_to = 1; has_peer = 0; next }
+    in_to && /^        - / { has_peer = 1; next }
+    in_to && /^      ports:$/ { if (!has_peer) exit 1; in_to = 0 }
+    in_to && /^    - / { if (!has_peer) exit 1; in_to = 0 }
+  ' "$rendered"; then
+    echo "expected every egress to block to contain at least one peer" >&2
+    exit 1
+  fi
+}
+
 assert_contains 'kind: NetworkPolicy'
 assert_contains 'name: "agent-workload-egress"'
 assert_contains 'namespace: "agyn-workloads"'
@@ -82,6 +94,26 @@ assert_contains 'cidr: "10.42.2.4/32"'
 assert_contains 'kubernetes.io/metadata.name: istio-system'
 assert_contains 'istio: ingressgateway'
 assert_contains 'port: 443'
+assert_no_empty_to_blocks
+
+cat >"$values_file" <<'VALUES'
+workloadNamespace: agyn-workloads
+workloadEgressNetworkPolicy:
+  enabled: true
+  zitiUnderlay:
+    endpoints:
+      - name: backend-only
+        backendCIDRs:
+          - 10.42.2.5/32
+        port: 443
+VALUES
+
+helm template k8s-runner "$chart_dir" \
+  -f "$values_file" \
+  >"$rendered"
+assert_contains 'cidr: "10.42.2.5/32"'
+assert_contains 'port: 443'
+assert_no_empty_to_blocks
 
 helm template k8s-runner "$chart_dir" \
   --set workloadNamespace=agyn-workloads \


### PR DESCRIPTION
## Summary

Fixes #73.

- Adds first-class Helm values for workload egress to `ziti-workload-dns` and `ziti-controller-client` enrollment.
- Renders optional NetworkPolicy rules for Ziti workload DNS TCP/UDP 53 and controller enrollment TCP on the configured `/32` CIDR/port.
- Keeps existing OpenZiti synthetic CIDR, kube-dns, public internet, and internal CIDR exclusion behavior unchanged.
- Adds Helm chart verification to CI and documents the bootstrap wiring expectation.

## Verification

- `git diff --check`
- `nix shell nixpkgs#kubernetes-helm -c scripts/verify-workload-egress-networkpolicy.sh`
- `nix shell nixpkgs#kubernetes-helm -c helm template k8s-runner charts/k8s-runner --set workloadNamespace=agyn-workloads --set workloadEgressNetworkPolicy.enabled=true --set workloadEgressNetworkPolicy.zitiWorkloadDNS.enabled=true --set workloadEgressNetworkPolicy.zitiControllerEnrollment.enabled=true --set workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr=10.43.245.186/32 --set workloadEgressNetworkPolicy.zitiControllerEnrollment.port=2496`
- `nix shell nixpkgs#buf -c buf generate --include-imports`
- `nix shell nixpkgs#gcc -c go test ./...`
- `nix shell nixpkgs#gcc -c go build ./...`

## Follow-up

Bootstrap #577 still needs to enable these chart values and set `workloadEgressNetworkPolicy.zitiControllerEnrollment.cidr` from the live `ziti-controller-client` ClusterIP before rerunning agynio/e2e PR #214 live workload verification.