### PR TITLE
fix(server): repair reused PVC labels

### DIFF
--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -637,7 +637,11 @@ func (s *Server) ensurePVC(ctx context.Context, volume *runnerv1.VolumeSpec, lab
 		return "", status.Errorf(codes.InvalidArgument, "invalid_pvc_name: %s", strings.Join(errs, ", "))
 	}
 
-	if _, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).Get(ctx, pvcName, metav1.GetOptions{}); err == nil {
+	existing, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).Get(ctx, pvcName, metav1.GetOptions{})
+	if err == nil {
+		if err := s.repairPVCLabels(ctx, existing, labels, volume.GetLabels()); err != nil {
+			return "", err
+		}
 		return pvcName, nil
 	} else if !apierrors.IsNotFound(err) {
 		return "", grpcErrorFromKube(s.logger, err, codes.Internal)
@@ -682,6 +686,45 @@ func (s *Server) ensurePVC(ctx context.Context, volume *runnerv1.VolumeSpec, lab
 
 	s.logger.Info("created pvc", zap.String("pvc", pvcName))
 	return pvcName, nil
+}
+
+func (s *Server) repairPVCLabels(ctx context.Context, pvc *corev1.PersistentVolumeClaim, workloadLabels map[string]string, volumeLabels map[string]string) error {
+	labels := map[string]string{
+		managedByLabelKey: managedByLabelValue,
+	}
+	for key, value := range workloadLabels {
+		if key == workloadIDLabelKey {
+			continue
+		}
+		labels[key] = value
+	}
+	if err := addLabels(labels, volumeLabels); err != nil {
+		return status.Errorf(codes.InvalidArgument, "invalid_volume_label: %v", err)
+	}
+
+	patched := false
+	merged := make(map[string]string, len(pvc.Labels)+len(labels))
+	for key, value := range pvc.Labels {
+		merged[key] = value
+	}
+	for key, value := range labels {
+		if merged[key] == value {
+			continue
+		}
+		merged[key] = value
+		patched = true
+	}
+	if !patched {
+		return nil
+	}
+
+	updated := pvc.DeepCopy()
+	updated.Labels = merged
+	if _, err := s.clientset.CoreV1().PersistentVolumeClaims(s.namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return grpcErrorFromKube(s.logger, err, codes.Internal)
+	}
+	s.logger.Info("repaired pvc labels", zap.String("pvc", pvc.Name))
+	return nil
 }
 
 func buildContainers(req *runnerv1.StartWorkloadRequest, volumes []corev1.Volume, inlineFileKeys map[string]string) ([]corev1.Container, []corev1.Container, []string, error) {

--- a/internal/server/workload.go
+++ b/internal/server/workload.go
@@ -689,6 +689,9 @@ func (s *Server) ensurePVC(ctx context.Context, volume *runnerv1.VolumeSpec, lab
 }
 
 func (s *Server) repairPVCLabels(ctx context.Context, pvc *corev1.PersistentVolumeClaim, workloadLabels map[string]string, volumeLabels map[string]string) error {
+	if pvc.Labels[managedByLabelKey] != managedByLabelValue {
+		return status.Errorf(codes.FailedPrecondition, "pvc_not_managed_by_runner: %s", pvc.Name)
+	}
 	labels := map[string]string{
 		managedByLabelKey: managedByLabelValue,
 	}

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -1057,6 +1057,119 @@ func TestStartWorkloadAppliesLabelsToPodAndPVC(t *testing.T) {
 	}
 }
 
+func TestStartWorkloadRepairsExistingPVCLabels(t *testing.T) {
+	ctx := context.Background()
+	clientset := fake.NewSimpleClientset(&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-data",
+			Namespace: "default",
+			Labels: map[string]string{
+				managedByLabelKey: managedByLabelValue,
+				volumeKeyLabelKey: "stale-volume-key",
+				"existing":        "kept",
+			},
+		},
+	})
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+	req := &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Labels: map[string]string{
+			workloadKeyLabelKey: "workload-key-2",
+			"team":              "core",
+		},
+		Volumes: []*runnerv1.VolumeSpec{
+			{
+				Name:           "data",
+				Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+				PersistentName: "pvc-data",
+				Labels: map[string]string{
+					volumeKeyLabelKey: "8b95765e-9fee-5b9b-a918-a1c06e994357",
+				},
+			},
+		},
+	}
+
+	if _, err := server.StartWorkload(ctx, req); err != nil {
+		t.Fatalf("StartWorkload returned error: %v", err)
+	}
+
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims("default").Get(ctx, "pvc-data", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pvc reused: %v", err)
+	}
+	if pvc.Labels[volumeKeyLabelKey] != "8b95765e-9fee-5b9b-a918-a1c06e994357" {
+		t.Fatalf("expected repaired volume key, got %q", pvc.Labels[volumeKeyLabelKey])
+	}
+	if pvc.Labels[workloadKeyLabelKey] != "workload-key-2" {
+		t.Fatalf("expected repaired workload key, got %q", pvc.Labels[workloadKeyLabelKey])
+	}
+	if pvc.Labels["team"] != "core" {
+		t.Fatalf("expected team label, got %q", pvc.Labels["team"])
+	}
+	if pvc.Labels["existing"] != "kept" {
+		t.Fatalf("expected existing label to be preserved")
+	}
+
+	volumes, err := server.ListVolumes(ctx, &runnerv1.ListVolumesRequest{})
+	if err != nil {
+		t.Fatalf("ListVolumes returned error: %v", err)
+	}
+	if len(volumes.Volumes) != 1 {
+		t.Fatalf("expected repaired pvc to be listed, got %d", len(volumes.Volumes))
+	}
+	if volumes.Volumes[0].GetInstanceId() != "pvc-data" || volumes.Volumes[0].GetVolumeKey() != "8b95765e-9fee-5b9b-a918-a1c06e994357" {
+		t.Fatalf("unexpected listed volume: %v", volumes.Volumes[0])
+	}
+}
+
+func TestStartWorkloadRepairsExistingPVCMissingVolumeKey(t *testing.T) {
+	ctx := context.Background()
+	clientset := fake.NewSimpleClientset(&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-data",
+			Namespace: "default",
+			Labels: map[string]string{
+				managedByLabelKey: managedByLabelValue,
+			},
+		},
+	})
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+	req := &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Volumes: []*runnerv1.VolumeSpec{
+			{
+				Name:           "data",
+				Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+				PersistentName: "pvc-data",
+				Labels: map[string]string{
+					volumeKeyLabelKey: "8b95765e-9fee-5b9b-a918-a1c06e994357",
+				},
+			},
+		},
+	}
+
+	if _, err := server.StartWorkload(ctx, req); err != nil {
+		t.Fatalf("StartWorkload returned error: %v", err)
+	}
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims("default").Get(ctx, "pvc-data", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pvc reused: %v", err)
+	}
+	if pvc.Labels[volumeKeyLabelKey] != "8b95765e-9fee-5b9b-a918-a1c06e994357" {
+		t.Fatalf("expected repaired volume key, got %q", pvc.Labels[volumeKeyLabelKey])
+	}
+}
+
 func TestStartWorkloadRejectsReservedVolumeLabel(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	server := New(Options{

--- a/internal/server/workload_test.go
+++ b/internal/server/workload_test.go
@@ -1170,6 +1170,54 @@ func TestStartWorkloadRepairsExistingPVCMissingVolumeKey(t *testing.T) {
 	}
 }
 
+func TestStartWorkloadRejectsUnmanagedExistingPVC(t *testing.T) {
+	ctx := context.Background()
+	clientset := fake.NewSimpleClientset(&corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-data",
+			Namespace: "default",
+			Labels: map[string]string{
+				"owner": "external",
+			},
+		},
+	})
+	server := New(Options{
+		Clientset:   clientset,
+		Namespace:   "default",
+		StorageSize: "1Gi",
+		Logger:      zap.NewNop(),
+	})
+	req := &runnerv1.StartWorkloadRequest{
+		Main: &runnerv1.ContainerSpec{Name: "main", Image: "busybox"},
+		Volumes: []*runnerv1.VolumeSpec{
+			{
+				Name:           "data",
+				Kind:           runnerv1.VolumeKind_VOLUME_KIND_NAMED,
+				PersistentName: "pvc-data",
+				Labels: map[string]string{
+					volumeKeyLabelKey: "8b95765e-9fee-5b9b-a918-a1c06e994357",
+				},
+			},
+		},
+	}
+
+	_, err := server.StartWorkload(ctx, req)
+	if err == nil {
+		t.Fatal("expected unmanaged pvc to be rejected")
+	}
+	st, ok := status.FromError(err)
+	if !ok || st.Code() != codes.FailedPrecondition {
+		t.Fatalf("expected failed precondition error, got %v", err)
+	}
+	pvc, err := clientset.CoreV1().PersistentVolumeClaims("default").Get(ctx, "pvc-data", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("expected pvc to remain: %v", err)
+	}
+	if pvc.Labels[managedByLabelKey] != "" {
+		t.Fatalf("expected unmanaged pvc to remain unlabeled, got %q", pvc.Labels[managedByLabelKey])
+	}
+}
+
 func TestStartWorkloadRejectsReservedVolumeLabel(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	server := New(Options{


### PR DESCRIPTION
## Summary

- Repairs labels on reused named PVCs before mounting them into restarted workloads.
- Updates stale or missing `volume_key` labels while preserving existing non-conflicting labels.
- Adds regression coverage for reused persistent PVCs with stale and missing labels.

Related to agynio/agents-orchestrator#228.

## Test & Lint Summary

- `go test ./...`: 88 passed / 0 failed / 0 skipped.
- `go build ./...`: passed.
- `scripts/verify-workload-egress-networkpolicy.sh`: passed.
- `git diff --check HEAD~1 HEAD`: passed with no whitespace/lint errors.