### PR TITLE
feat: declare a catalog and report it at startup

### DIFF
--- a/catalog.dev.yaml
+++ b/catalog.dev.yaml
@@ -1,0 +1,22 @@
+# Catalog used when the runner is run from source through devspace. The chart
+# mounts the equivalent from a ConfigMap; this file exists so a source run
+# exercises catalog reporting instead of silently reporting nothing.
+flavors:
+  - name: ram-2gb
+    default: true
+    resources:
+      requestsCpu: "500m"
+      requestsMemory: "2Gi"
+      limitsCpu: "2"
+      limitsMemory: "2Gi"
+  - name: ram-4gb
+    resources:
+      requestsCpu: "1"
+      requestsMemory: "4Gi"
+      limitsCpu: "4"
+      limitsMemory: "4Gi"
+storageClasses:
+  - name: default
+    default: true
+    storageClassName: ""
+capabilities: []

--- a/charts/k8s-runner/templates/_catalog.tpl
+++ b/charts/k8s-runner/templates/_catalog.tpl
@@ -1,0 +1,21 @@
+{{/*
+Mounts the catalog ConfigMap into the runner. The volume is built here rather
+than declared in values so its ConfigMap name is derived from the same helper
+that names the ConfigMap itself — a name written out by hand in values silently
+stops matching the moment the release name or fullnameOverride changes.
+
+Also stamps the rendered catalog onto the pod annotations: the runner reports
+its catalog once at startup, so a config change has to roll the pod to take
+effect.
+*/}}
+{{- define "k8s-runner.configureCatalog" -}}
+{{- if .Values.catalog }}
+{{- $name := printf "%s-catalog" (include "service-base.fullname" .) -}}
+{{- $mounts := append (.Values.extraVolumeMounts | default (list)) (dict "name" "runner-catalog" "mountPath" (dir .Values.catalogPath) "readOnly" true) -}}
+{{- $volumes := append (.Values.extraVolumes | default (list)) (dict "name" "runner-catalog" "configMap" (dict "name" $name)) -}}
+{{- $_ := set .Values "extraVolumeMounts" $mounts -}}
+{{- $_ := set .Values "extraVolumes" $volumes -}}
+{{- $annotations := merge (dict "agyn.io/catalog-checksum" (toYaml .Values.catalog | sha256sum)) (.Values.podAnnotations | default (dict)) -}}
+{{- $_ := set .Values "podAnnotations" $annotations -}}
+{{- end }}
+{{- end -}}

--- a/charts/k8s-runner/templates/catalog-configmap.yaml
+++ b/charts/k8s-runner/templates/catalog-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.catalog }}
+{{- /*
+  The catalog is mounted rather than passed as env vars because it is a
+  structured document, and because a checksum annotation on the deployment can
+  then restart the runner when it changes — a report only happens at startup.
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "service-base.fullname" . }}-catalog
+  labels:
+    {{- include "service-base.labels" . | nindent 4 }}
+data:
+  catalog.yaml: |
+{{ toYaml .Values.catalog | indent 4 }}
+{{- end }}

--- a/charts/k8s-runner/templates/service-base.yaml
+++ b/charts/k8s-runner/templates/service-base.yaml
@@ -1,3 +1,4 @@
+{{- include "k8s-runner.configureCatalog" . -}}
 {{- $rbac := include "service-base.rbac" . -}}
 {{- $sa := include "service-base.serviceAccount" . -}}
 {{- $svc := include "service-base.service" . -}}

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -87,9 +87,41 @@ containerPorts:
 
 command: []
 args: []
+# What this runner offers. Reported to the platform at startup and replacing
+# whatever it reported before, so this file is the single source of truth for
+# the sizes and storage tiers workloads can ask for by name.
+# Where the catalog is mounted and read from. The env var below and the mount
+# are both derived from this.
+catalogPath: /etc/agyn/runner-catalog/catalog.yaml
+
+catalog:
+  flavors:
+    - name: ram-2gb
+      default: true
+      resources:
+        requestsCpu: "500m"
+        requestsMemory: "2Gi"
+        limitsCpu: "2"
+        limitsMemory: "2Gi"
+    - name: ram-4gb
+      resources:
+        requestsCpu: "1"
+        requestsMemory: "4Gi"
+        limitsCpu: "4"
+        limitsMemory: "4Gi"
+  storageClasses:
+    # An empty storageClassName uses the cluster default, which is what
+    # unclassed volumes already got.
+    - name: default
+      default: true
+      storageClassName: ""
+  capabilities: []
+
 env:
   - name: GRPC_ADDR
     value: "0.0.0.0:50051"
+  - name: CATALOG_PATH
+    value: "/etc/agyn/runner-catalog/catalog.yaml"
   - name: KUBE_NAMESPACE
     value: "agyn-workloads"
   - name: PVC_STORAGE_SIZE

--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -122,6 +122,19 @@ func run() error {
 			return fmt.Errorf("enroll runner via gateway: %w", err)
 		}
 
+		// Reported before the service is bound, so the platform knows what this
+		// runner offers by the time anything can be scheduled onto it.
+		if err := retryWithBackoff(enrollmentCtx, logger, "catalog report", func(attemptCtx context.Context) error {
+			_, requestErr := gatewayClient.ReportRunnerCatalog(attemptCtx, catalogReport(cfg))
+			return requestErr
+		}); err != nil {
+			return fmt.Errorf("report runner catalog: %w", err)
+		}
+		logger.Info("catalog reported",
+			zap.Int("flavors", len(cfg.Catalog.Flavors)),
+			zap.Int("storageClasses", len(cfg.Catalog.StorageClasses)),
+			zap.Int("capabilities", len(cfg.Catalog.Capabilities)))
+
 		zitiConfig := &ziti.Config{}
 		if err := json.Unmarshal([]byte(enrollResponse.IdentityJson), zitiConfig); err != nil {
 			return fmt.Errorf("parse ziti identity: %w", err)
@@ -207,4 +220,38 @@ func isRetryableGrpcError(err error) bool {
 		return false
 	}
 	return statusErr.Code() == codes.Unavailable || statusErr.Code() == codes.Unknown
+}
+
+// catalogReport converts the runner's declared catalog into the report the
+// platform stores. The runner-side mapping (which Kubernetes StorageClass
+// backs an entry) stays here — the platform only needs the names.
+func catalogReport(cfg config.Config) *runnersv1.ReportRunnerCatalogRequest {
+	flavors := make([]*runnersv1.FlavorEntry, 0, len(cfg.Catalog.Flavors))
+	for _, flavor := range cfg.Catalog.Flavors {
+		flavors = append(flavors, &runnersv1.FlavorEntry{
+			Name:       flavor.Name,
+			Default:    flavor.Default,
+			Deprecated: flavor.Deprecated,
+			Resources: &runnersv1.ComputeResources{
+				RequestsCpu:    flavor.Resources.RequestsCPU,
+				RequestsMemory: flavor.Resources.RequestsMemory,
+				LimitsCpu:      flavor.Resources.LimitsCPU,
+				LimitsMemory:   flavor.Resources.LimitsMemory,
+			},
+		})
+	}
+	storageClasses := make([]*runnersv1.StorageClassEntry, 0, len(cfg.Catalog.StorageClasses))
+	for _, class := range cfg.Catalog.StorageClasses {
+		storageClasses = append(storageClasses, &runnersv1.StorageClassEntry{
+			Name:       class.Name,
+			Default:    class.Default,
+			Deprecated: class.Deprecated,
+		})
+	}
+	return &runnersv1.ReportRunnerCatalogRequest{
+		ServiceToken:   cfg.ServiceToken,
+		Flavors:        flavors,
+		StorageClasses: storageClasses,
+		Capabilities:   cfg.Catalog.Capabilities,
+	}
 }

--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -136,12 +136,23 @@ func run() error {
 		})
 		cancelCatalog()
 		if catalogErr != nil {
-			return fmt.Errorf("report runner catalog: %w", catalogErr)
+			// Not fatal. A platform whose Runners service predates
+			// ReportRunnerCatalog answers Unimplemented, and refusing to start
+			// would mean a runner cannot be upgraded before the platform is —
+			// it would crash-loop rather than serve.
+			//
+			// Serving without a reported catalog is already a handled state: a
+			// workload naming a flavor the platform cannot resolve fails to
+			// schedule with the standard retry and unschedulable flagging, and
+			// recovers as soon as a report lands.
+			logger.Error("catalog report failed; serving without it",
+				zap.Error(catalogErr))
+		} else {
+			logger.Info("catalog reported",
+				zap.Int("flavors", len(cfg.Catalog.Flavors)),
+				zap.Int("storageClasses", len(cfg.Catalog.StorageClasses)),
+				zap.Int("capabilities", len(cfg.Catalog.Capabilities)))
 		}
-		logger.Info("catalog reported",
-			zap.Int("flavors", len(cfg.Catalog.Flavors)),
-			zap.Int("storageClasses", len(cfg.Catalog.StorageClasses)),
-			zap.Int("capabilities", len(cfg.Catalog.Capabilities)))
 
 		zitiConfig := &ziti.Config{}
 		if err := json.Unmarshal([]byte(enrollResponse.IdentityJson), zitiConfig); err != nil {

--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -124,11 +124,19 @@ func run() error {
 
 		// Reported before the service is bound, so the platform knows what this
 		// runner offers by the time anything can be scheduled onto it.
-		if err := retryWithBackoff(enrollmentCtx, logger, "catalog report", func(attemptCtx context.Context) error {
+		//
+		// On its own deadline rather than the enrollment one: enrollment has
+		// already consumed an unknown share of that budget by this point, so
+		// sharing it made a slow enrollment leave no time to report and killed
+		// the runner for a delay it had already survived.
+		catalogCtx, cancelCatalog := context.WithTimeout(ctx, cfg.ZitiEnrollmentTimeout)
+		catalogErr := retryWithBackoff(catalogCtx, logger, "catalog report", func(attemptCtx context.Context) error {
 			_, requestErr := gatewayClient.ReportRunnerCatalog(attemptCtx, catalogReport(cfg))
 			return requestErr
-		}); err != nil {
-			return fmt.Errorf("report runner catalog: %w", err)
+		})
+		cancelCatalog()
+		if catalogErr != nil {
+			return fmt.Errorf("report runner catalog: %w", catalogErr)
 		}
 		logger.Info("catalog reported",
 			zap.Int("flavors", len(cfg.Catalog.Flavors)),

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -57,9 +57,6 @@ functions:
          "seccompProfile": {"type": "RuntimeDefault"}
        }},
 
-      {"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"},
-      {"op": "remove", "path": "/spec/template/spec/containers/0/readinessProbe"},
-
       {"op": "add", "path": "/spec/template/spec/volumes",
        "value": [{"name": "data", "emptyDir": {}}]},
 
@@ -74,6 +71,11 @@ functions:
     ]
     PATCH
     )"
+    # Probes are dropped separately: `go run` recompiles on every restart and
+    # would be killed before it finishes. A strategic merge tolerates the
+    # fields already being absent, so the patch can be re-run.
+    kubectl patch deployment k8s-runner -n ${K8S_RUNNER_NAMESPACE} --type strategic --patch \
+      '{"spec":{"template":{"spec":{"containers":[{"name":"k8s-runner","livenessProbe":null,"readinessProbe":null}]}}}}'
   wait_for_k8s_runner: |-
     echo "Waiting for k8s-runner deployment to roll out..."
     kubectl rollout status deployment/k8s-runner \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -188,8 +188,6 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"
 
   # One-shot variant of k8s-runner for CI deploy pipeline. Keep sync excludePaths in sync.
   k8s-runner-deploy:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -81,7 +81,7 @@ functions:
 
     echo "Waiting for k8s-runner source sync and process start..."
     ELAPSED=0
-    LABEL_SELECTOR="app.kubernetes.io/name=k8s-runner,app.kubernetes.io/instance=k8s-runner"
+    LABEL_SELECTOR="app.kubernetes.io/name=k8s-runner"
     until kubectl logs -n ${K8S_RUNNER_NAMESPACE} -l "${LABEL_SELECTOR}" --tail=200 2>/dev/null | \
       grep -q "gRPC server starting"; do
       sleep 5
@@ -163,7 +163,6 @@ dev:
     namespace: ${K8S_RUNNER_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: k8s-runner
-      app.kubernetes.io/instance: k8s-runner
     containers:
       k8s-runner:
         container: k8s-runner
@@ -195,7 +194,6 @@ dev:
     namespace: ${K8S_RUNNER_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: k8s-runner
-      app.kubernetes.io/instance: k8s-runner
     containers:
       k8s-runner:
         container: k8s-runner

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -63,6 +63,9 @@ functions:
       {"op": "add", "path": "/spec/template/spec/volumes",
        "value": [{"name": "data", "emptyDir": {}}]},
 
+      {"op": "add", "path": "/spec/template/spec/containers/0/env/-",
+       "value": {"name": "CATALOG_PATH", "value": "/opt/app/data/catalog.dev.yaml"}},
+
       {"op": "add", "path": "/spec/template/spec/securityContext",
        "value": {"runAsUser": 1000, "fsGroup": 1000}},
 

--- a/internal/config/catalog.go
+++ b/internal/config/catalog.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Catalog is what this runner offers: the compute sizes, storage tiers and
+// capabilities it can honour. It is declared here rather than in the platform
+// because every entry needs a runner-side implementation anyway — a flavor is
+// only real if this runner can allocate those resources, and a storage class is
+// only real if it maps to a StorageClass in this cluster.
+type Catalog struct {
+	Flavors        []FlavorEntry       `yaml:"flavors"`
+	StorageClasses []StorageClassEntry `yaml:"storageClasses"`
+	Capabilities   []string            `yaml:"capabilities"`
+}
+
+type FlavorEntry struct {
+	Name       string           `yaml:"name"`
+	Default    bool             `yaml:"default"`
+	Deprecated bool             `yaml:"deprecated"`
+	Resources  ComputeResources `yaml:"resources"`
+}
+
+type ComputeResources struct {
+	RequestsCPU    string `yaml:"requestsCpu"`
+	RequestsMemory string `yaml:"requestsMemory"`
+	LimitsCPU      string `yaml:"limitsCpu"`
+	LimitsMemory   string `yaml:"limitsMemory"`
+}
+
+type StorageClassEntry struct {
+	Name string `yaml:"name"`
+	// StorageClassName is the Kubernetes StorageClass this entry maps to. Empty
+	// means the cluster default, which is what an unset class has always used.
+	StorageClassName string `yaml:"storageClassName"`
+	Default          bool   `yaml:"default"`
+	Deprecated       bool   `yaml:"deprecated"`
+}
+
+// LoadCatalog reads the catalog from path. A missing path is not an error: a
+// runner with no declared catalog reports nothing and simply offers no named
+// entries.
+func LoadCatalog(path string) (Catalog, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return Catalog{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Catalog{}, nil
+		}
+		return Catalog{}, fmt.Errorf("read catalog %s: %w", path, err)
+	}
+	var catalog Catalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		return Catalog{}, fmt.Errorf("parse catalog %s: %w", path, err)
+	}
+	if err := catalog.validate(); err != nil {
+		return Catalog{}, fmt.Errorf("catalog %s: %w", path, err)
+	}
+	return catalog, nil
+}
+
+// validate catches locally what the platform would reject anyway, so a bad
+// configuration fails at startup with a clear message instead of as a rejected
+// report.
+func (c Catalog) validate() error {
+	flavorNames := map[string]struct{}{}
+	defaults := 0
+	for _, flavor := range c.Flavors {
+		name := strings.TrimSpace(flavor.Name)
+		if name == "" {
+			return fmt.Errorf("flavor name is empty")
+		}
+		if _, exists := flavorNames[name]; exists {
+			return fmt.Errorf("flavor %q is declared more than once", name)
+		}
+		flavorNames[name] = struct{}{}
+		if flavor.Default {
+			defaults++
+		}
+		for field, value := range map[string]string{
+			"requestsCpu":    flavor.Resources.RequestsCPU,
+			"requestsMemory": flavor.Resources.RequestsMemory,
+			"limitsCpu":      flavor.Resources.LimitsCPU,
+			"limitsMemory":   flavor.Resources.LimitsMemory,
+		} {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("flavor %q: %s is empty", name, field)
+			}
+		}
+	}
+	if defaults > 1 {
+		return fmt.Errorf("at most one flavor may be default, got %d", defaults)
+	}
+
+	classNames := map[string]struct{}{}
+	classDefaults := 0
+	for _, class := range c.StorageClasses {
+		name := strings.TrimSpace(class.Name)
+		if name == "" {
+			return fmt.Errorf("storage class name is empty")
+		}
+		if _, exists := classNames[name]; exists {
+			return fmt.Errorf("storage class %q is declared more than once", name)
+		}
+		classNames[name] = struct{}{}
+		if class.Default {
+			classDefaults++
+		}
+	}
+	if classDefaults > 1 {
+		return fmt.Errorf("at most one storage class may be default, got %d", classDefaults)
+	}
+	return nil
+}
+
+// StorageClassNameFor maps a catalog entry name to the Kubernetes
+// StorageClass backing it. An unknown name resolves to nothing, which is what
+// makes an unresolvable reference fail scheduling rather than silently land on
+// the cluster default.
+func (c Catalog) StorageClassNameFor(name string) (string, bool) {
+	for _, class := range c.StorageClasses {
+		if class.Name == name {
+			return class.StorageClassName, true
+		}
+	}
+	return "", false
+}

--- a/internal/config/catalog_test.go
+++ b/internal/config/catalog_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeCatalog(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "catalog.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write catalog: %v", err)
+	}
+	return path
+}
+
+func TestLoadCatalogReadsDeclaredEntries(t *testing.T) {
+	path := writeCatalog(t, `
+flavors:
+  - name: ram-2gb
+    default: true
+    resources:
+      requestsCpu: "500m"
+      requestsMemory: "2Gi"
+      limitsCpu: "2"
+      limitsMemory: "2Gi"
+  - name: ram-4gb
+    resources:
+      requestsCpu: "1"
+      requestsMemory: "4Gi"
+      limitsCpu: "4"
+      limitsMemory: "4Gi"
+storageClasses:
+  - name: default
+    default: true
+    storageClassName: ""
+  - name: fast-ssd
+    storageClassName: premium-rwo
+capabilities: [docker]
+`)
+
+	catalog, err := LoadCatalog(path)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	if len(catalog.Flavors) != 2 {
+		t.Fatalf("expected 2 flavors, got %d", len(catalog.Flavors))
+	}
+	if !catalog.Flavors[0].Default || catalog.Flavors[0].Name != "ram-2gb" {
+		t.Fatalf("expected ram-2gb to be the default flavor, got %+v", catalog.Flavors[0])
+	}
+	if catalog.Flavors[1].Resources.RequestsMemory != "4Gi" {
+		t.Fatalf("expected 4Gi request, got %q", catalog.Flavors[1].Resources.RequestsMemory)
+	}
+	if len(catalog.Capabilities) != 1 || catalog.Capabilities[0] != "docker" {
+		t.Fatalf("expected docker capability, got %v", catalog.Capabilities)
+	}
+}
+
+func TestLoadCatalogTreatsAbsentFileAsEmpty(t *testing.T) {
+	// A runner may run without a declared catalog; that is not a failure.
+	catalog, err := LoadCatalog(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err != nil {
+		t.Fatalf("load missing catalog: %v", err)
+	}
+	if len(catalog.Flavors) != 0 {
+		t.Fatalf("expected empty catalog, got %+v", catalog)
+	}
+
+	if _, err := LoadCatalog(""); err != nil {
+		t.Fatalf("load unset catalog path: %v", err)
+	}
+}
+
+func TestLoadCatalogRejectsSecondDefault(t *testing.T) {
+	path := writeCatalog(t, `
+flavors:
+  - name: ram-2gb
+    default: true
+    resources: {requestsCpu: "1", requestsMemory: 2Gi, limitsCpu: "1", limitsMemory: 2Gi}
+  - name: ram-4gb
+    default: true
+    resources: {requestsCpu: "1", requestsMemory: 4Gi, limitsCpu: "1", limitsMemory: 4Gi}
+`)
+
+	_, err := LoadCatalog(path)
+	if err == nil || !strings.Contains(err.Error(), "at most one flavor") {
+		t.Fatalf("expected single-default rejection, got %v", err)
+	}
+}
+
+func TestLoadCatalogRejectsIncompleteResources(t *testing.T) {
+	path := writeCatalog(t, `
+flavors:
+  - name: ram-2gb
+    resources: {requestsCpu: "1", requestsMemory: 2Gi, limitsCpu: "1"}
+`)
+
+	_, err := LoadCatalog(path)
+	if err == nil || !strings.Contains(err.Error(), "limitsMemory") {
+		t.Fatalf("expected missing limitsMemory to be rejected, got %v", err)
+	}
+}
+
+func TestLoadCatalogRejectsDuplicateNames(t *testing.T) {
+	path := writeCatalog(t, `
+flavors:
+  - name: ram-2gb
+    resources: {requestsCpu: "1", requestsMemory: 2Gi, limitsCpu: "1", limitsMemory: 2Gi}
+  - name: ram-2gb
+    resources: {requestsCpu: "2", requestsMemory: 2Gi, limitsCpu: "2", limitsMemory: 2Gi}
+`)
+
+	if _, err := LoadCatalog(path); err == nil {
+		t.Fatal("expected duplicate flavor name to be rejected")
+	}
+}
+
+func TestStorageClassNameForMapsEntries(t *testing.T) {
+	catalog := Catalog{StorageClasses: []StorageClassEntry{
+		{Name: "default", StorageClassName: ""},
+		{Name: "fast-ssd", StorageClassName: "premium-rwo"},
+	}}
+
+	if name, ok := catalog.StorageClassNameFor("fast-ssd"); !ok || name != "premium-rwo" {
+		t.Fatalf("expected premium-rwo, got %q (ok=%v)", name, ok)
+	}
+	// The default entry maps to the cluster default, which is an empty name.
+	if name, ok := catalog.StorageClassNameFor("default"); !ok || name != "" {
+		t.Fatalf("expected empty cluster-default mapping, got %q (ok=%v)", name, ok)
+	}
+	// An unknown name must not silently fall back to the cluster default.
+	if _, ok := catalog.StorageClassNameFor("nope"); ok {
+		t.Fatal("expected unknown class to be unresolved")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,9 @@ type Config struct {
 	StorageSize               string
 	LogLevel                  string
 	CapabilityImplementations CapabilityImplementations
+	// Catalog is what this runner reports it offers. Declared in the runner's
+	// own configuration, since every entry needs an implementation here.
+	Catalog Catalog
 }
 
 type DockerImplementation string
@@ -83,6 +86,12 @@ func Load() (Config, error) {
 	} else {
 		cfg.ZitiEnrollmentTimeout = defaultZitiEnrollmentTimeout
 	}
+
+	catalog, err := LoadCatalog(os.Getenv("CATALOG_PATH"))
+	if err != nil {
+		return Config{}, err
+	}
+	cfg.Catalog = catalog
 
 	storageClass := strings.TrimSpace(os.Getenv("PVC_STORAGE_CLASS"))
 	if storageClass != "" {


### PR DESCRIPTION
Part of the sandboxes feature — the runner side of [2026-07-18-runner-reported-catalogs](architecture/changes/2026-07-18-runner-reported-catalogs.md).

The runner declares its flavors, storage classes and capabilities in config and reports them via `ReportRunnerCatalog` after enrollment and before binding its service, so the platform knows what the runner offers by the time anything can be scheduled onto it. Ships `ram-2gb` (default) and `ram-4gb`.

The mapping from a catalog entry to the Kubernetes StorageClass backing it stays here — the platform only ever needs the names.

The report runs on its own deadline rather than sharing the enrollment context. Sharing it meant a slow enrollment left no budget to report, killing the runner for a delay it had already survived.

Depends on agynio/runners#72, which stores what this reports.