### PR TITLE
Report the capabilities this runner is configured for

### DIFF
--- a/cmd/k8s-runner/catalog_capabilities_test.go
+++ b/cmd/k8s-runner/catalog_capabilities_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/agynio/k8s-runner/internal/config"
+)
+
+// The catalog listed capabilities by hand while the runner decided what it
+// could serve from its configured implementations, and the two disagreed:
+// docker was configured and working, the catalog said nothing, and the
+// Orchestrator refused to place any agent that asked for it -- "no eligible
+// runners found (required capabilities: [docker])".
+func TestCatalogCapabilitiesReportsConfiguredDocker(t *testing.T) {
+	cfg := config.Config{CapabilityImplementations: config.CapabilityImplementations{
+		Docker: config.DockerImplementationRootless,
+	}}
+
+	if got := catalogCapabilities(cfg); !reflect.DeepEqual(got, []string{"docker"}) {
+		t.Fatalf("expected [docker], got %v", got)
+	}
+}
+
+// Without an implementation the runner cannot serve it, so it must not claim it.
+func TestCatalogCapabilitiesOmitsUnconfiguredDocker(t *testing.T) {
+	if got := catalogCapabilities(config.Config{}); len(got) != 0 {
+		t.Fatalf("expected no capabilities, got %v", got)
+	}
+}
+
+// The catalog entry still stands on its own, so an operator can advertise
+// something ahead of the implementation, and listing docker there as well does
+// not report it twice.
+func TestCatalogCapabilitiesMergesTheCatalogEntry(t *testing.T) {
+	cfg := config.Config{
+		Catalog: config.Catalog{Capabilities: []string{"docker", " gpu "}},
+		CapabilityImplementations: config.CapabilityImplementations{
+			Docker: config.DockerImplementationPrivileged,
+		},
+	}
+
+	if got := catalogCapabilities(cfg); !reflect.DeepEqual(got, []string{"docker", "gpu"}) {
+		t.Fatalf("expected [docker gpu], got %v", got)
+	}
+}

--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -8,6 +8,8 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sort"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -271,6 +273,39 @@ func catalogReport(cfg config.Config) *runnersv1.ReportRunnerCatalogRequest {
 		ServiceToken:   cfg.ServiceToken,
 		Flavors:        flavors,
 		StorageClasses: storageClasses,
-		Capabilities:   cfg.Catalog.Capabilities,
+		Capabilities:   catalogCapabilities(cfg),
 	}
+}
+
+// catalogCapabilities reports what this runner can actually do, which is what
+// it has an implementation configured for. The catalog listed them separately
+// and the two silently disagreed: docker was configured and working, the
+// catalog said nothing, and the Orchestrator placed no agent that asked for it
+// -- "no eligible runners found (required capabilities: [docker])" -- with the
+// runner right there able to serve them.
+//
+// The catalog entry is still honoured, so a capability can be advertised ahead
+// of the implementation landing, but it no longer has to be kept in step by
+// hand for the ones the runner already implements.
+func catalogCapabilities(cfg config.Config) []string {
+	capabilities := make([]string, 0, len(cfg.Catalog.Capabilities)+1)
+	seen := map[string]struct{}{}
+	add := func(capability string) {
+		if capability == "" {
+			return
+		}
+		if _, ok := seen[capability]; ok {
+			return
+		}
+		seen[capability] = struct{}{}
+		capabilities = append(capabilities, capability)
+	}
+	for _, capability := range cfg.Catalog.Capabilities {
+		add(strings.TrimSpace(capability))
+	}
+	if cfg.CapabilityImplementations.Docker != "" {
+		add(config.CapabilityDocker)
+	}
+	sort.Strings(capabilities)
+	return capabilities
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,11 @@ type Config struct {
 	Catalog Catalog
 }
 
+// CapabilityDocker is the capability name a workload asks for and the runner
+// reports. Named here rather than in the server package so the startup report
+// and the request handling cannot drift apart.
+const CapabilityDocker = "docker"
+
 type DockerImplementation string
 
 const (

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	dockerCapability              = "docker"
+	dockerCapability              = config.CapabilityDocker
 	dockerSidecarName             = "docker-daemon"
 	dockerDataVolumeName          = "docker-data"
 	dockerRunVolumeName           = "docker-run"


### PR DESCRIPTION
`catalog.capabilities` is a hand-maintained list, while `resolveCapabilityPlan` decides what the runner can actually serve from `CAPABILITY_IMPLEMENTATIONS`. The two disagreed silently.

On the platform VM the runner runs with `CAPABILITY_IMPLEMENTATIONS={"docker":"rootless"}` — docker fully works — but `catalog.capabilities: []`, so the Orchestrator refused to place any agent requiring it:

```
select runner for agent c5a52020 instance 4a34bada: no eligible runners found
(required capabilities: [docker], missing capabilities: 8639a5f0-...:[docker])
```

The startup report is now derived from the configured implementations, unioned with the catalog entry so a capability can still be advertised ahead of its implementation landing. Both sides take the name from one constant so they cannot drift again.