### PR TITLE
Give up when the Ziti identity stops being accepted

### DIFF
--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -35,6 +35,11 @@ const (
 	retryMaxBackoff     = 15 * time.Second
 )
 
+const (
+	zitiIdentityCheckInterval    = 30 * time.Second
+	zitiIdentityFailureThreshold = 5
+)
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "k8s-runner failed: %v\n", err)
@@ -173,6 +178,15 @@ func run() error {
 		}
 		defer zitiListener.Close()
 		startServe(zitiListener, "ziti")
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := watchZitiIdentity(ctx, zitiContext.RefreshServices, zitiIdentityCheckInterval, zitiIdentityFailureThreshold, logger)
+			if err != nil {
+				errCh <- err
+			}
+		}()
 	}
 
 	select {
@@ -308,4 +322,37 @@ func catalogCapabilities(cfg config.Config) []string {
 	}
 	sort.Strings(capabilities)
 	return capabilities
+}
+
+// The runner enrols once, at startup. If the controller stops accepting that
+// identity -- it was deleted, or the controller lost it -- the SDK retries the
+// bind forever and the runner stays Running with no terminator, so the platform
+// keeps scheduling onto a runner nothing can reach. Exiting hands the problem to
+// Kubernetes, which restarts the pod into a fresh enrolment.
+func watchZitiIdentity(ctx context.Context, refresh func() error, interval time.Duration, threshold int, logger *zap.Logger) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	failures := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := refresh(); err != nil {
+			failures++
+			logger.Warn("ziti identity check failed",
+				zap.Int("consecutiveFailures", failures), zap.Error(err))
+			if failures >= threshold {
+				return fmt.Errorf("ziti identity is no longer usable after %d checks: %w", failures, err)
+			}
+			continue
+		}
+		if failures > 0 {
+			logger.Info("ziti identity recovered", zap.Int("afterFailures", failures))
+		}
+		failures = 0
+	}
 }

--- a/cmd/k8s-runner/ziti_identity_test.go
+++ b/cmd/k8s-runner/ziti_identity_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// The SDK retries a rejected bind forever, so the runner stayed Running with no
+// terminator and the platform kept scheduling onto something nothing could
+// reach. Giving up lets Kubernetes restart it into a fresh enrolment.
+func TestWatchZitiIdentityGivesUpAfterThreshold(t *testing.T) {
+	calls := 0
+	err := watchZitiIdentity(context.Background(), func() error {
+		calls++
+		return errors.New("credential submission failed with status 401")
+	}, time.Millisecond, 3, zap.NewNop())
+
+	if err == nil {
+		t.Fatal("expected an error once the threshold was reached")
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 checks, got %d", calls)
+	}
+}
+
+// A single failed check is not a lost identity.
+func TestWatchZitiIdentityResetsAfterRecovery(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := watchZitiIdentity(ctx, func() error {
+		calls++
+		switch {
+		case calls < 3:
+			return errors.New("transient")
+		case calls >= 6:
+			cancel()
+		}
+		return nil
+	}, time.Millisecond, 3, zap.NewNop())
+
+	if err != nil {
+		t.Fatalf("expected recovery to clear the failures, got %v", err)
+	}
+}
+
+func TestWatchZitiIdentityStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := watchZitiIdentity(ctx, func() error { return errors.New("unused") }, time.Millisecond, 3, zap.NewNop()); err != nil {
+		t.Fatalf("expected a clean stop, got %v", err)
+	}
+}


### PR DESCRIPTION
The runner enrols once at startup. When the controller stops accepting that identity, the SDK retries the bind forever: the pod stays Running with no terminator, so the Orchestrator keeps scheduling onto a runner nothing can dial (`has no terminators`, `desired=9 actual=0`), and no workload ever starts. Exiting hands it to Kubernetes, which restarts into a fresh enrolment.