### PR TITLE
Reach the ziti control plane by default, and stop naming its ports

### DIFF
--- a/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
+++ b/charts/k8s-runner/templates/workload-egress-networkpolicy.yaml
@@ -120,9 +120,11 @@ spec:
               {{- toYaml . | nindent 14 }}
           {{- end }}
         {{- end }}
+      {{- with $endpoint.port }}
       ports:
         - protocol: TCP
-          port: {{ required (printf "workloadEgressNetworkPolicy.zitiUnderlay.endpoints[%s].port is required" (default "unnamed" $endpoint.name)) $endpoint.port }}
+          port: {{ . }}
+      {{- end }}
     {{- end }}
     - to:
         - ipBlock:

--- a/charts/k8s-runner/values.yaml
+++ b/charts/k8s-runner/values.yaml
@@ -238,35 +238,31 @@ workloadEgressNetworkPolicy:
       kubernetes.io/metadata.name: ziti
     podSelector:
       app.kubernetes.io/name: ziti-workload-dns
-  # At least one entry is required while the policy is enabled: it excludes
-  # every private range, so without an allowance here a workload cannot reach
-  # the ziti controller it enrols against and no agent starts. The template
-  # fails rather than render a policy that severs the overlay.
+  # The policy excludes every private range, so without an allowance here a
+  # workload cannot reach the ziti controller it enrols against and no agent
+  # starts. The default reaches the control plane where this platform puts it;
+  # an installation whose ziti lives elsewhere replaces these entries.
   #
-  # port is the *pod's* port, not the Service's. A NetworkPolicy is evaluated
-  # after the Service DNAT, so naming the Service port matches nothing.
+  # No port is named on purpose. A NetworkPolicy is evaluated after the Service
+  # DNAT, so it matches the *pod's* port -- an implementation detail of the
+  # upstream ziti charts, which a version bump is free to change. Selecting the
+  # namespace alone cannot rot that way, and the namespace holds nothing a
+  # workload should be denied.
   zitiUnderlay:
-    endpoints: []
-    # Example:
-    # - name: controller
-    #   namespaceSelector:
-    #     kubernetes.io/metadata.name: ziti
-    #   port: 1280
-    # - name: router
-    #   namespaceSelector:
-    #     kubernetes.io/metadata.name: ziti
-    #   port: 3022
+    endpoints:
+      - name: ziti-control-plane
+        namespaceSelector:
+          kubernetes.io/metadata.name: ziti
+    # An entry may narrow itself to one port, at the cost of tracking what the
+    # ziti pods listen on: the controller's 1280 and the router's 3022, neither
+    # of which is the 2496 their Services publish.
+    #
     # - name: ingress-gateway
     #   cidr: ""
     #   backendCIDRs: []
     #   namespaceSelector: {}
     #   podSelector: {}
     #   port: 443
-    # - name: router
-    #   cidr: ""
-    #   namespaceSelector: {}
-    #   podSelector: {}
-    #   port: 2496
   # Deprecated compatibility alias. Prefer zitiUnderlay.endpoints.
   zitiControllerEnrollment:
     enabled: false


### PR DESCRIPTION
The egress policy excludes every private range, so a workload could only reach the controller it enrols against if the installation named it. Nothing did — the default was `endpoints: []`, and an install supplying no value got a policy that rendered cleanly, left every pod green, and let no agent start. Enrolment succeeds, the tunnel never forms, the workload waits on a gateway it cannot route to.

Observed: `agyn-platform 0.18.1` (k8s-runner 0.10.15) upgraded a VM at 02:26 and every workload since has hung at `ziti-gateway-wait`.

**Default now reaches the control plane's namespace.** An installation that puts ziti elsewhere replaces the entry.

**`port` becomes optional, and the default names none.** A NetworkPolicy is evaluated after the Service DNAT, so it matches the *pod's* port — 1280 and 3022, not the 2496 both Services publish. Those belong to the upstream ziti charts and a version bump is free to move them, which would sever the overlay again with nothing to say so. An endpoint may still name a port where narrower is wanted.

Verified:
- stock `helm template`, no overrides → egress rule selecting the `ziti` namespace, no port restriction
- `endpoints: []` explicitly → still fails, per #79
- endpoint with a port → still renders `ports:`