### PR TITLE
Name the overlay .agyn, not .ziti

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ runtime Istio ingress gateway, and router underlay endpoints returned by
 endpoint/backend pod CIDRs through `backendCIDRs`, a namespace/pod selector,
 or a combination. Runtime `ziti.<base-domain>:443` resolves to
 the Istio ingress gateway so TLS passthrough can route SNI to the controller
-client service. This keeps `.ziti` application traffic on the overlay while
+client service. This keeps `.agyn` application traffic on the overlay while
 allowing only the underlay endpoints required for sidecar startup:
 
 ```yaml


### PR DESCRIPTION
Renames the OpenZiti overlay hostnames from `.ziti` to `.agyn`:
`gateway.agyn`, `llm-proxy.agyn`, `tracing.agyn`, and `exposed-<uuid>.agyn`.

The TLD was never a DNS zone — the workload tunneler answers only for
hostnames an `intercept.v1` config names, and forwards everything else
upstream. So this is a naming change, not a networking one.

Not touched: the `ziti` Kubernetes namespace and `*.ziti.svc.cluster.local`,
the `ziti.<domain>` CoreDNS rewrites, and the `ziti-workload-dns` zone keys.

Coordinated across expose, agents-orchestrator, agynd-cli, agyn-cli,
networks, egress, files-mcp, platform-charts, bundle-vm, e2e,
platform-controller and the docs. There is no installed base to migrate.