### PR TITLE
Say when a workload is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ runtime Istio ingress gateway, and router underlay endpoints returned by
 endpoint/backend pod CIDRs through `backendCIDRs`, a namespace/pod selector,
 or a combination. Runtime `ziti.<base-domain>:443` resolves to
 the Istio ingress gateway so TLS passthrough can route SNI to the controller
-client service. This keeps `.ziti` application traffic on the overlay while
+client service. This keeps `.agyn` application traffic on the overlay while
 allowing only the underlay endpoints required for sidecar startup:
 
 ```yaml

--- a/cmd/k8s-runner/main.go
+++ b/cmd/k8s-runner/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/agynio/k8s-runner/internal/config"
 	"github.com/agynio/k8s-runner/internal/kube"
 	"github.com/agynio/k8s-runner/internal/logging"
+	"github.com/agynio/k8s-runner/internal/reporter"
 	"github.com/agynio/k8s-runner/internal/server"
 )
 
@@ -185,6 +186,19 @@ func run() error {
 			err := watchZitiIdentity(ctx, zitiContext.RefreshServices, zitiIdentityCheckInterval, zitiIdentityFailureThreshold, logger)
 			if err != nil {
 				errCh <- err
+			}
+		}()
+
+		// The platform used to discover a workload was running by dialing this
+		// runner on its reconcile interval and asking.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			workloadReporter := reporter.New(kubeClient.Clientset, cfg.Namespace, gatewayClient, cfg.ServiceToken, logger)
+			if err := workloadReporter.Run(ctx); err != nil && ctx.Err() == nil {
+				// Not fatal: reconciliation still converges without it, so a
+				// runner that cannot report serves on and is late, not wrong.
+				logger.Warn("workload state reporting stopped", zap.Error(err))
 			}
 		}()
 	}

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect

--- a/internal/reporter/reporter.go
+++ b/internal/reporter/reporter.go
@@ -1,0 +1,214 @@
+// Package reporter tells the platform what the runner sees.
+//
+// The platform used to ask. The Agents Orchestrator dialed the runner on its
+// reconcile interval and called InspectWorkload, so a workload was ready and
+// serving for up to a full interval before anything recorded it -- and the
+// sandbox behind it stayed "starting" for exactly that long. The runner is the
+// only component that can see a Pod, so it is the only one that can say when.
+package reporter
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+
+	gatewayv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/gateway/v1"
+	runnersv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runners/v1"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// WorkloadIDLabel is set by this runner when it creates the Pod, so a Pod maps
+// to a workload record with no lookup.
+const WorkloadIDLabel = "agyn.io/workload-id"
+
+const (
+	resyncInterval = 30 * time.Second
+	reportTimeout  = 10 * time.Second
+	retryBackoff   = time.Second
+	retryAttempts  = 3
+)
+
+type Reporter struct {
+	clientset    kubernetes.Interface
+	namespace    string
+	gateway      gatewayv1.RunnersGatewayClient
+	serviceToken string
+	logger       *zap.Logger
+
+	// reported is the last status sent per workload, so a resync or an
+	// unrelated Pod update does not resend what the platform already has.
+	mu       sync.Mutex
+	reported map[string]runnersv1.WorkloadStatus
+}
+
+func New(clientset kubernetes.Interface, namespace string, gateway gatewayv1.RunnersGatewayClient, serviceToken string, logger *zap.Logger) *Reporter {
+	return &Reporter{
+		clientset:    clientset,
+		namespace:    namespace,
+		gateway:      gateway,
+		serviceToken: serviceToken,
+		logger:       logger,
+		reported:     map[string]runnersv1.WorkloadStatus{},
+	}
+}
+
+// Run watches the workload Pods in this runner's namespace until ctx ends.
+//
+// An informer rather than a bare watch for its two recovery properties: it
+// reconnects when the API server drops the watch, and it re-lists on resync, so
+// a transition missed during a disconnect is re-derived rather than lost.
+func (r *Reporter) Run(ctx context.Context) error {
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		r.clientset,
+		resyncInterval,
+		informers.WithNamespace(r.namespace),
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = WorkloadIDLabel
+		}),
+	)
+	pods := factory.Core().V1().Pods().Informer()
+	if _, err := pods.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { r.observe(ctx, obj) },
+		UpdateFunc: func(_, obj any) { r.observe(ctx, obj) },
+		DeleteFunc: r.forget,
+	}); err != nil {
+		return err
+	}
+	factory.Start(ctx.Done())
+	factory.WaitForCacheSync(ctx.Done())
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// observe reports a Pod's runtime state when it is one the platform does not
+// already have. Anything that is neither running nor failed is a transition in
+// progress and says nothing worth sending.
+func (r *Reporter) observe(ctx context.Context, obj any) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	workloadID := strings.TrimSpace(pod.Labels[WorkloadIDLabel])
+	if workloadID == "" {
+		return
+	}
+	observed, ok := workloadStatus(pod)
+	if !ok {
+		return
+	}
+	if !r.changed(workloadID, observed) {
+		return
+	}
+	r.report(ctx, workloadID, observed)
+}
+
+// forget drops a deleted Pod's last reported status so a workload restarted
+// under the same id reports again from scratch.
+//
+// Deliberately reports nothing itself. A deleted Pod means the workload is gone,
+// and ending a workload is the platform's decision -- the Orchestrator's
+// reconciliation notices the absence and settles what it means.
+func (r *Reporter) forget(obj any) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		if tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown); isTombstone {
+			pod, ok = tombstone.Obj.(*corev1.Pod)
+		}
+		if !ok {
+			return
+		}
+	}
+	workloadID := strings.TrimSpace(pod.Labels[WorkloadIDLabel])
+	if workloadID == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.reported, workloadID)
+	r.mu.Unlock()
+}
+
+func (r *Reporter) changed(workloadID string, observed runnersv1.WorkloadStatus) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if last, ok := r.reported[workloadID]; ok && last == observed {
+		return false
+	}
+	r.reported[workloadID] = observed
+	return true
+}
+
+// report is best-effort. A failure is retried a few times and then dropped: the
+// Orchestrator's reconciliation is the backstop, so a runner that cannot report
+// is behind on latency, not on correctness.
+func (r *Reporter) report(ctx context.Context, workloadID string, observed runnersv1.WorkloadStatus) {
+	observedAt := timestamppb.Now()
+	for attempt := 0; attempt < retryAttempts; attempt++ {
+		callCtx, cancel := context.WithTimeout(ctx, reportTimeout)
+		_, err := r.gateway.ReportWorkloadState(callCtx, &runnersv1.ReportWorkloadStateRequest{
+			ServiceToken: r.serviceToken,
+			WorkloadId:   workloadID,
+			Status:       observed,
+			ObservedAt:   observedAt,
+		})
+		cancel()
+		if err == nil {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		// A platform older than this RPC answers Unimplemented. It reconciles on
+		// its own interval exactly as it always did, so the runner keeps serving
+		// and simply stops trying to help.
+		if status.Code(err) == codes.Unimplemented {
+			r.logger.Info("platform does not accept workload state reports; leaving it to reconciliation")
+			return
+		}
+		if attempt == retryAttempts-1 {
+			r.logger.Warn("report workload state",
+				zap.String("workload_id", workloadID),
+				zap.String("status", observed.String()),
+				zap.Error(err))
+			// Forgotten so the next observation retries rather than being
+			// suppressed as already reported.
+			r.mu.Lock()
+			delete(r.reported, workloadID)
+			r.mu.Unlock()
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(retryBackoff << attempt):
+		}
+	}
+}
+
+// workloadStatus reads the runtime state a Pod is in.
+//
+// Running means every container is ready, not merely that the Pod exists: the
+// platform marks a sandbox usable on this signal, and a Pod whose containers are
+// still starting is not one a shell can attach to.
+func workloadStatus(pod *corev1.Pod) (runnersv1.WorkloadStatus, bool) {
+	switch pod.Status.Phase {
+	case corev1.PodFailed:
+		return runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED, true
+	case corev1.PodRunning:
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				return runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING, true
+			}
+		}
+	}
+	return runnersv1.WorkloadStatus_WORKLOAD_STATUS_UNSPECIFIED, false
+}

--- a/internal/reporter/reporter_test.go
+++ b/internal/reporter/reporter_test.go
@@ -1,0 +1,78 @@
+package reporter
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	runnersv1 "github.com/agynio/k8s-runner/internal/.gen/agynio/api/runners/v1"
+)
+
+func podWith(phase corev1.PodPhase, ready corev1.ConditionStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{WorkloadIDLabel: "workload-1"}},
+		Status: corev1.PodStatus{
+			Phase:      phase,
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: ready}},
+		},
+	}
+}
+
+// The platform marks a sandbox usable on this signal, so a Pod whose containers
+// are still starting is not one to call running -- a shell cannot attach to it.
+func TestWorkloadStatusRequiresReadyNotMerelyRunning(t *testing.T) {
+	observed, ok := workloadStatus(podWith(corev1.PodRunning, corev1.ConditionTrue))
+	if !ok || observed != runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING {
+		t.Fatalf("expected a ready pod to report running, got %v (ok=%v)", observed, ok)
+	}
+
+	if _, ok := workloadStatus(podWith(corev1.PodRunning, corev1.ConditionFalse)); ok {
+		t.Fatal("expected a running-but-unready pod to report nothing")
+	}
+}
+
+func TestWorkloadStatusReportsFailure(t *testing.T) {
+	observed, ok := workloadStatus(podWith(corev1.PodFailed, corev1.ConditionFalse))
+	if !ok || observed != runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED {
+		t.Fatalf("expected a failed pod to report failed, got %v (ok=%v)", observed, ok)
+	}
+}
+
+// Pending and succeeded are transitions in progress or an ending the platform
+// owns; neither is something a runner reports.
+func TestWorkloadStatusStaysSilentOnEverythingElse(t *testing.T) {
+	for _, phase := range []corev1.PodPhase{corev1.PodPending, corev1.PodSucceeded, corev1.PodUnknown} {
+		if _, ok := workloadStatus(podWith(phase, corev1.ConditionFalse)); ok {
+			t.Errorf("expected phase %s to report nothing", phase)
+		}
+	}
+}
+
+// Every Pod update and every resync re-delivers the same object. Without this
+// the runner would resend a state the platform already has, on a timer.
+func TestChangedSuppressesARepeatOfTheSameStatus(t *testing.T) {
+	r := New(nil, "ns", nil, "token", nil)
+
+	if !r.changed("workload-1", runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING) {
+		t.Fatal("expected the first observation to be reported")
+	}
+	if r.changed("workload-1", runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING) {
+		t.Fatal("expected a repeat of the same status to be suppressed")
+	}
+	if !r.changed("workload-1", runnersv1.WorkloadStatus_WORKLOAD_STATUS_FAILED) {
+		t.Fatal("expected a different status to be reported")
+	}
+}
+
+// A workload restarted under the same id must report again from scratch.
+func TestForgetClearsTheRememberedStatus(t *testing.T) {
+	r := New(nil, "ns", nil, "token", nil)
+	r.changed("workload-1", runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING)
+
+	r.forget(podWith(corev1.PodRunning, corev1.ConditionTrue))
+
+	if !r.changed("workload-1", runnersv1.WorkloadStatus_WORKLOAD_STATUS_RUNNING) {
+		t.Fatal("expected a forgotten workload to report again")
+	}
+}


### PR DESCRIPTION
A pod informer inside the existing process reports each runtime transition to the platform, so it learns a workload is ready from the only component that can see it.

No extra pod and no RBAC change — `watch` on pods is already granted, and pods already carry `agyn.io/workload-id`. An informer rather than a bare watch for its recovery properties: it reconnects and re-lists on resync, so a transition missed during a disconnect is re-derived.

Running means every container is Ready, not that the pod exists. Deletion reports nothing — ending a workload is the platform's decision. Best-effort throughout; a platform answering `Unimplemented` is left to reconcile.

Spec: [k8s Runner — Workload State Reporting](https://github.com/agynio/architecture/blob/main/architecture/k8s-runner.md#workload-state-reporting)